### PR TITLE
Added data directory to gemspec

### DIFF
--- a/paypal-sdk-rest.gemspec
+++ b/paypal-sdk-rest.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   
   gem.license       = "PayPal SDK License"
 
-  gem.files         = Dir["{bin,spec,lib}/**/*"] + ["Rakefile", "README.md", "Gemfile"]
+  gem.files         = Dir["{bin,spec,lib}/**/*"] + ["Rakefile", "README.md", "Gemfile"] + Dir["data/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
data/paypal.crt is hard coded as default certificate file in HTTPHelper#default_ca_file, but was not packed up in gem.