### PR TITLE
Added missing time_stamp field in AgreementTransaction

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1883,6 +1883,7 @@ module PayPal::SDK
           object_of :payer_name, String
           object_of :time_updated, String
           object_of :time_zone, String
+          object_of :time_stamp, DateTime
         end
       end
 


### PR DESCRIPTION
time_stamp was missing from AgreementTransaction, created new DateTime field for time_stamp in AgreementTransaction members object.