### PR TITLE
add missing fields to ShippingAdress and Transaction

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -456,6 +456,8 @@ module PayPal::SDK
           object_of :postal_code, String
           object_of :country_code, String
           object_of :phone, String
+          object_of :normalization_status, String
+          object_of :id, String
           object_of :recipient_name, String
         end
       end
@@ -475,6 +477,7 @@ module PayPal::SDK
           object_of :custom, String
           object_of :soft_descriptor, String
           object_of :item_list, ItemList
+          object_of :notify_url, String
           object_of :purchase_unit_reference_id, String
           array_of  :related_resources, RelatedResources
           array_of  :transactions, Transaction


### PR DESCRIPTION
Missing fields for ShippingAddress: id, normalization_status
Missing fields for Transaction: notify_url

I've noticed "undefined method" errors on these fields and found them described in [documentation] (https://developer.paypal.com/docs/rest/api/payments/). 

I've also noticed next errors:

    # on executing approved payment
    undefined method `coupled_group=' for #<PayPal::SDK::REST::DataTypes::Sale:0x0000000882f6b0>
    undefined method `soft_descriptor=' for #<PayPal::SDK::REST::DataTypes::Sale:0x0000000882f6b0>
    # on GET https://api.paypal.com/v1/notifications/webhooks-events/
    undefined method `encType=' for #<PayPal::SDK::REST::DataTypes::Links:0x007f2547767370>

But they're not defined in documentation yet.
