### PR TITLE
Convert specs to RSpec 3.4.1 syntax with Transpec

### DIFF
--- a/spec/core/api/data_type_spec.rb
+++ b/spec/core/api/data_type_spec.rb
@@ -31,29 +31,29 @@ describe PayPal::SDK::Core::API::DataTypes::Base do
 
   it "should allow content key" do
     message = Message.new("Testing message")
-    message.value.should eql "Testing message"
+    expect(message.value).to eql "Testing message"
 
     message = Message.new(:value => "Testing message")
-    message.value.should eql "Testing message"
+    expect(message.value).to eql "Testing message"
   end
 
   it "should create member object automatically" do
     test_type = TestType.new
-    test_type.fromCurrency.should   be_a TestCurrency
-    test_type.toCurrency.should     be_a Array
-    test_type.toCurrency[0].should  be_a TestCurrency
-    test_type.toCurrency[1].should  be_a TestCurrency
-    test_type.toCurrency[0].amount.should eql nil
-    test_type.fromCurrency.amount.should  eql nil
-    test_type.fromCurrency.desciption.should    eql nil
-    test_type.fromCurrency.currencyID.should    eql nil
+    expect(test_type.fromCurrency).to   be_a TestCurrency
+    expect(test_type.toCurrency).to     be_a Array
+    expect(test_type.toCurrency[0]).to  be_a TestCurrency
+    expect(test_type.toCurrency[1]).to  be_a TestCurrency
+    expect(test_type.toCurrency[0].amount).to eql nil
+    expect(test_type.fromCurrency.amount).to  eql nil
+    expect(test_type.fromCurrency.desciption).to    eql nil
+    expect(test_type.fromCurrency.currencyID).to    eql nil
   end
 
   it "should convert the given data to configured type" do
     test_type = TestType.new( :fromCurrency => { :currencyID => "USD", :amount => "50.0"})
-    test_type.fromCurrency.should be_a TestCurrency
-    test_type.fromCurrency.currencyID.should    eql "USD"
-    test_type.fromCurrency.amount.should  eql "50.0"
+    expect(test_type.fromCurrency).to be_a TestCurrency
+    expect(test_type.fromCurrency.currencyID).to    eql "USD"
+    expect(test_type.fromCurrency.amount).to  eql "50.0"
   end
 
   it "should allow block with initializer" do
@@ -63,8 +63,8 @@ describe PayPal::SDK::Core::API::DataTypes::Base do
         self.amount = "50.0"
       end
     end
-    test_type.fromCurrency.currencyID.should    eql "USD"
-    test_type.fromCurrency.amount.should  eql "50.0"
+    expect(test_type.fromCurrency.currencyID).to    eql "USD"
+    expect(test_type.fromCurrency.amount).to  eql "50.0"
   end
 
   it "should allow block with member" do
@@ -73,116 +73,116 @@ describe PayPal::SDK::Core::API::DataTypes::Base do
       self.currencyID = "USD"
       self.amount = "50.0"
     end
-    test_type.fromCurrency.currencyID.should    eql "USD"
-    test_type.fromCurrency.amount.should  eql "50.0"
+    expect(test_type.fromCurrency.currencyID).to    eql "USD"
+    expect(test_type.fromCurrency.amount).to  eql "50.0"
   end
 
   it "should assign value to attribute" do
     test_currency = TestCurrency.new( :@currencyID => "USD", :amount => "50" )
-    test_currency.currencyID.should eql "USD"
+    expect(test_currency.currencyID).to eql "USD"
   end
 
   it "should allow configured Class object" do
     test_currency = TestCurrency.new( :currencyID => "USD", :amount => "50" )
     test_type = TestType.new( :fromCurrency => test_currency )
-    test_type.fromCurrency.should eql test_currency
+    expect(test_type.fromCurrency).to eql test_currency
   end
 
   it "should allow snakecase" do
     test_type = TestType.new( :from_currency => {} )
-    test_type.from_currency.should be_a TestCurrency
-    test_type.from_currency.should eql test_type.fromCurrency
+    expect(test_type.from_currency).to be_a TestCurrency
+    expect(test_type.from_currency).to eql test_type.fromCurrency
   end
 
   it "should allow array" do
     test_type = TestType.new( :toCurrency => [{ :currencyID => "USD", :amount => "50.0" }] )
-    test_type.toCurrency.should be_a Array
-    test_type.toCurrency.first.should be_a TestCurrency
-    test_type.toCurrency.first.currencyID.should eql "USD"
+    expect(test_type.toCurrency).to be_a Array
+    expect(test_type.toCurrency.first).to be_a TestCurrency
+    expect(test_type.toCurrency.first.currencyID).to eql "USD"
   end
 
   it "should skip undefind members on initializer" do
     test_type = TestType.new( :notExist => "testing")
-    lambda do
+    expect do
       test_type.notExist
-    end.should raise_error NoMethodError
-    lambda do
+    end.to raise_error NoMethodError
+    expect do
       test_type.notExist = "Value"
-    end.should raise_error NoMethodError
+    end.to raise_error NoMethodError
   end
 
   it "should not convert empty hash" do
     test_type = TestType.new( :fromCurrency => {} )
-    test_type.to_hash.should eql({})
+    expect(test_type.to_hash).to eql({})
   end
 
   it "should not convert empty array" do
     test_type = TestType.new( :toCurrency => [] )
-    test_type.to_hash.should eql({})
+    expect(test_type.to_hash).to eql({})
   end
 
   it "should not convert array of empty hash" do
     test_type = TestType.new( :toCurrency => [ {} ] )
-    test_type.to_hash.should eql({})
+    expect(test_type.to_hash).to eql({})
   end
 
   it "should return empty hash" do
     test_type = TestType.new
-    test_type.to_hash.should eql({})
+    expect(test_type.to_hash).to eql({})
   end
 
   it "should convert to hash" do
     test_currency = TestCurrency.new(:amount => "500")
-    test_currency.to_hash.should eql("amount" => "500")
+    expect(test_currency.to_hash).to eql("amount" => "500")
   end
 
   it "should convert to hash with key as symbol" do
     test_currency = TestCurrency.new(:amount => "500")
-    test_currency.to_hash(:symbol => true).should eql(:amount => "500")
+    expect(test_currency.to_hash(:symbol => true)).to eql(:amount => "500")
   end
 
   it "should convert attribute key with @" do
     test_currency = TestCurrency.new( :currencyID => "USD", :amount => "50" )
-    test_currency.to_hash["@currencyID"].should eql "USD"
+    expect(test_currency.to_hash["@currencyID"]).to eql "USD"
   end
 
   it "should convert attribute key without @" do
     test_currency = TestCurrency.new( :currencyID => "USD", :amount => "50" )
-    test_currency.to_hash(:attribute => false)["currencyID"].should eql "USD"
+    expect(test_currency.to_hash(:attribute => false)["currencyID"]).to eql "USD"
   end
 
   it "should convert to hash with namespace" do
     test_currency = TestCurrency.new(:currencyID => "USD", :amount => "500", :desciption => "Testing" )
     hash = test_currency.to_hash
-    hash["amount"].should eql "500"
-    hash["ns:desciption"].should eql "Testing"
-    hash["@currencyID"].should eql "USD"
+    expect(hash["amount"]).to eql "500"
+    expect(hash["ns:desciption"]).to eql "Testing"
+    expect(hash["@currencyID"]).to eql "USD"
     hash = test_currency.to_hash(:namespace => false)
-    hash["amount"].should eql "500"
-    hash["desciption"].should eql "Testing"
-    hash["@currencyID"].should eql "USD"
+    expect(hash["amount"]).to eql "500"
+    expect(hash["desciption"]).to eql "Testing"
+    expect(hash["@currencyID"]).to eql "USD"
   end
 
   it "should allow namespace" do
     test_currency = TestCurrency.new(:amount => "500", :"ns:desciption" => "Testing" )
-    test_currency.desciption.should eql "Testing"
+    expect(test_currency.desciption).to eql "Testing"
   end
 
   it "should use name option in members" do
     test_type = TestType.new( :firstname => "FirstName")
-    test_type.to_hash.should eql({"first-name" => "FirstName" })
+    expect(test_type.to_hash).to eql({"first-name" => "FirstName" })
   end
 
   it "should allow date" do
     date_time = "2010-10-10T10:10:10"
     test_simple_type = TestSimpleType.new( :created_on => date_time, :created_at => date_time )
-    test_simple_type.created_on.should be_a Date
-    test_simple_type.created_at.should be_a DateTime
+    expect(test_simple_type.created_on).to be_a Date
+    expect(test_simple_type.created_at).to be_a DateTime
   end
 
   it "should allow date with value 0" do
     test_simple_type = TestSimpleType.new( :created_at => "0" )
-    test_simple_type.created_at.should be_a DateTime
+    expect(test_simple_type.created_at).to be_a DateTime
   end
 
 end

--- a/spec/core/api/rest_spec.rb
+++ b/spec/core/api/rest_spec.rb
@@ -22,68 +22,68 @@ describe PayPal::SDK::Core::API::REST do
   describe "Configuration" do
     it "create api with prefix" do
       api = create_api("v1/payments")
-      api.uri.path.should eql "/v1/payments"
+      expect(api.uri.path).to eql "/v1/payments"
     end
 
     it "service endpoint for sandbox" do
       api = create_api
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://api.sandbox.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.sandbox.paypal.com"
       api = create_api( :mode => "sandbox" )
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://api.sandbox.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.sandbox.paypal.com"
       api = create_api( :mode => :sandbox )
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://api.sandbox.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.sandbox.paypal.com"
       api = create_api( :mode => "invalid" )
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://api.sandbox.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.sandbox.paypal.com"
       api = create_api( :mode => nil )
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://api.sandbox.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.sandbox.paypal.com"
     end
 
     it "service endpoint for live" do
       api = create_api( :mode => "live" )
-      api.service_endpoint.should eql "https://api.paypal.com"
-      api.token_endpoint.should   eql "https://api.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.paypal.com"
       api = create_api( :mode => :live )
-      api.service_endpoint.should eql "https://api.paypal.com"
-      api.token_endpoint.should   eql "https://api.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.paypal.com"
+      expect(api.token_endpoint).to   eql "https://api.paypal.com"
     end
 
     it "override service endpoint" do
       api = create_api( :rest_endpoint => "https://testing.api.paypal.com" )
-      api.service_endpoint.should eql "https://testing.api.paypal.com"
-      api.token_endpoint.should   eql "https://testing.api.paypal.com"
+      expect(api.service_endpoint).to eql "https://testing.api.paypal.com"
+      expect(api.token_endpoint).to   eql "https://testing.api.paypal.com"
       api = create_api( :endpoint => "https://testing.api.paypal.com" )
-      api.service_endpoint.should eql "https://testing.api.paypal.com"
-      api.token_endpoint.should   eql "https://testing.api.paypal.com"
+      expect(api.service_endpoint).to eql "https://testing.api.paypal.com"
+      expect(api.token_endpoint).to   eql "https://testing.api.paypal.com"
     end
 
     it "override token endpoint" do
       api = create_api( :rest_token_endpoint => "https://testing.api.paypal.com" )
-      api.service_endpoint.should eql "https://api.sandbox.paypal.com"
-      api.token_endpoint.should   eql "https://testing.api.paypal.com"
+      expect(api.service_endpoint).to eql "https://api.sandbox.paypal.com"
+      expect(api.token_endpoint).to   eql "https://testing.api.paypal.com"
     end
   end
 
   describe "Validation" do
     it "Invalid client_id and client_secret" do
       api = create_api(:with_authentication, :client_id => "XYZ", :client_secret => "ABC")
-      lambda {
+      expect {
         api.token
-      }.should raise_error PayPal::SDK::Core::Exceptions::UnauthorizedAccess
+      }.to raise_error PayPal::SDK::Core::Exceptions::UnauthorizedAccess
     end
 
     xit "Should handle expired token" do
       old_token = @api.token
       @api.token_hash[:expires_in] = 0
-      @api.token.should_not eql old_token
+      expect(@api.token).not_to eql old_token
     end
 
     it "Get token" do
-      @api.token.should_not be_nil
+      expect(@api.token).not_to be_nil
     end
   end
 
@@ -104,13 +104,13 @@ describe PayPal::SDK::Core::API::REST do
           "amount" => {
             "total" => "7.47",
             "currency" => "USD" }}]})
-      response["error"].should be_nil
+      expect(response["error"]).to be_nil
     end
 
     it "List Payments" do
       response = @api.get("payment", { "count" => 10 })
-      response["error"].should be_nil
-      response["count"].should_not be_nil
+      expect(response["error"]).to be_nil
+      expect(response["count"]).not_to be_nil
     end
 
     it "Execute Payment"
@@ -122,26 +122,26 @@ describe PayPal::SDK::Core::API::REST do
         "expire_month" =>  "11", "expire_year" =>  "2018",
         "cvv2" =>  "874",
         "first_name" =>  "Joe", "last_name" =>  "Shopper" })
-      new_funding_instrument["error"].should  be_nil
-      new_funding_instrument["id"].should_not be_nil
+      expect(new_funding_instrument["error"]).to  be_nil
+      expect(new_funding_instrument["id"]).not_to be_nil
 
       funding_instrument = @vault_api.get("credit-card/#{new_funding_instrument["id"]}")
-      funding_instrument["error"].should be_nil
-      funding_instrument["id"].should eql new_funding_instrument["id"]
+      expect(funding_instrument["error"]).to be_nil
+      expect(funding_instrument["id"]).to eql new_funding_instrument["id"]
     end
 
   end
 
   describe "Failure request", :integration => true do
     it "Invalid Resource ID" do
-      lambda {
+      expect {
         response = @api.get("payment/PAY-1234")
-      }.should raise_error PayPal::SDK::Core::Exceptions::ResourceNotFound
+      }.to raise_error PayPal::SDK::Core::Exceptions::ResourceNotFound
     end
 
     it "Invalid parameters" do
       response = @api.post("payment")
-      response["error"]["name"].should eql "VALIDATION_ERROR"
+      expect(response["error"]["name"]).to eql "VALIDATION_ERROR"
     end
   end
 end

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -5,17 +5,17 @@ describe PayPal::SDK::Core::Config do
   Config = PayPal::SDK::Core::Config
 
   it "load configuration file and default environment" do
-    lambda {
+    expect {
       Config.load("spec/config/paypal.yml", "test")
-      Config.default_environment.should eql "test"
-    }.should_not raise_error
+      expect(Config.default_environment).to eql "test"
+    }.not_to raise_error
   end
 
   it "Set default environment" do
     begin
       backup_default_environment = Config.default_environment
       Config.default_environment = "new_env"
-      Config.default_environment.should eql "new_env"
+      expect(Config.default_environment).to eql "new_env"
     ensure
       Config.default_environment = backup_default_environment
     end
@@ -25,9 +25,9 @@ describe PayPal::SDK::Core::Config do
     begin
       backup_configurations = Config.configurations
       Config.configurations = { Config.default_environment => { :username => "direct", :password => "direct" } }
-      Config.config.username.should eql "direct"
-      Config.config.password.should eql "direct"
-      Config.config.signature.should be_nil
+      expect(Config.config.username).to eql "direct"
+      expect(Config.config.password).to eql "direct"
+      expect(Config.config.signature).to be_nil
     ensure
       Config.configurations = backup_configurations
     end
@@ -38,8 +38,8 @@ describe PayPal::SDK::Core::Config do
       backup_configurations = Config.configurations
       Config.configurations = nil
       Config.configure( :username => "Testing" )
-      Config.config.username.should eql "Testing"
-      Config.config.app_id.should be_nil
+      expect(Config.config.username).to eql "Testing"
+      expect(Config.config.app_id).to be_nil
     ensure
       Config.configurations = backup_configurations
     end
@@ -52,8 +52,8 @@ describe PayPal::SDK::Core::Config do
       Config.configure do |config|
         config.username = "Testing"
       end
-      Config.config.username.should eql "Testing"
-      Config.config.app_id.should be_nil
+      expect(Config.config.username).to eql "Testing"
+      expect(Config.config.app_id).to be_nil
     ensure
       Config.configurations = backup_configurations
     end
@@ -66,9 +66,9 @@ describe PayPal::SDK::Core::Config do
       Config.configure do |config|
         config.username = "Testing"
       end
-      Config.config.username.should eql "Testing"
-      Config.config.app_id.should_not be_nil
-      Config.config.app_id.should eql default_config.app_id
+      expect(Config.config.username).to eql "Testing"
+      expect(Config.config.app_id).not_to be_nil
+      expect(Config.config.app_id).to eql default_config.app_id
     ensure
       Config.configurations = backup_configurations
     end
@@ -76,59 +76,59 @@ describe PayPal::SDK::Core::Config do
 
   it "validate configuration" do
     config = Config.new( :username => "XYZ")
-    lambda {
+    expect {
       config.required!(:username)
-    }.should_not raise_error
-    lambda {
+    }.not_to raise_error
+    expect {
       config.required!(:password)
-    }.should raise_error "Required configuration(password)"
-    lambda {
+    }.to raise_error "Required configuration(password)"
+    expect {
       config.required!(:username, :password)
-    }.should raise_error "Required configuration(password)"
-    lambda {
+    }.to raise_error "Required configuration(password)"
+    expect {
       config.required!(:password, :signature)
-    }.should raise_error "Required configuration(password, signature)"
+    }.to raise_error "Required configuration(password, signature)"
   end
 
   it "return default environment configuration" do
-    Config.config.should be_a Config
+    expect(Config.config).to be_a Config
   end
 
   it "return configuration based on environment" do
-    Config.config(:development).should be_a Config
+    expect(Config.config(:development)).to be_a Config
   end
 
   it "override default configuration" do
     override_configuration = { :username => "test.example.com", :app_id => "test"}
     config = Config.config(override_configuration)
 
-    config.username.should eql(override_configuration[:username])
-    config.app_id.should eql(override_configuration[:app_id])
+    expect(config.username).to eql(override_configuration[:username])
+    expect(config.app_id).to eql(override_configuration[:app_id])
   end
 
   it "get cached config" do
-    Config.config(:test).should eql Config.config(:test)
-    Config.config(:test).should_not eql Config.config(:development)
+    expect(Config.config(:test)).to eql Config.config(:test)
+    expect(Config.config(:test)).not_to eql Config.config(:development)
   end
 
   it "should raise error on invalid environment" do
-    lambda {
+    expect {
       Config.config(:invalid_env)
-    }.should raise_error "Configuration[invalid_env] NotFound"
+    }.to raise_error "Configuration[invalid_env] NotFound"
   end
 
   it "set logger" do
     require 'logger'
     my_logger = Logger.new(STDERR)
     Config.logger = my_logger
-    Config.logger.should eql my_logger
+    expect(Config.logger).to eql my_logger
   end
 
   it "Access PayPal::SDK methods" do
-    PayPal::SDK.configure.should eql PayPal::SDK::Core::Config.config
-    PayPal::SDK.logger.should eql PayPal::SDK::Core::Config.logger
+    expect(PayPal::SDK.configure).to eql PayPal::SDK::Core::Config.config
+    expect(PayPal::SDK.logger).to eql PayPal::SDK::Core::Config.logger
     PayPal::SDK.logger = PayPal::SDK.logger
-    PayPal::SDK.logger.should eql PayPal::SDK::Core::Config.logger
+    expect(PayPal::SDK.logger).to eql PayPal::SDK::Core::Config.logger
   end
 
   describe "include Configuration" do
@@ -138,38 +138,38 @@ describe PayPal::SDK::Core::Config do
 
     it "Get default configuration" do
       test_object = TestConfig.new
-      test_object.config.should be_a Config
+      expect(test_object.config).to be_a Config
     end
 
     it "Change environment" do
       test_object = TestConfig.new
       test_object.set_config("test")
-      test_object.config.should eql Config.config("test")
-      test_object.config.should_not eql Config.config("development")
+      expect(test_object.config).to eql Config.config("test")
+      expect(test_object.config).not_to eql Config.config("development")
     end
 
     it "Override environment configuration" do
       test_object = TestConfig.new
       test_object.set_config("test", :username => "test")
-      test_object.config.should_not eql Config.config("test")
+      expect(test_object.config).not_to eql Config.config("test")
     end
 
     it "Override default/current configuration" do
       test_object = TestConfig.new
       test_object.set_config( :username => "test")
-      test_object.config.username.should eql "test"
+      expect(test_object.config.username).to eql "test"
       test_object.set_config( :password => "test")
-      test_object.config.password.should eql "test"
-      test_object.config.username.should eql "test"
+      expect(test_object.config.password).to eql "test"
+      expect(test_object.config.username).to eql "test"
     end
 
     it "Append ssl_options" do
       test_object = TestConfig.new
       test_object.set_config( :ssl_options => { :ca_file => "test_path" } )
-      test_object.config.ssl_options[:ca_file].should eql "test_path"
+      expect(test_object.config.ssl_options[:ca_file]).to eql "test_path"
       test_object.set_config( :ssl_options => { :verify_mode => 1 } )
-      test_object.config.ssl_options[:verify_mode].should eql 1
-      test_object.config.ssl_options[:ca_file].should eql "test_path"
+      expect(test_object.config.ssl_options[:verify_mode]).to eql 1
+      expect(test_object.config.ssl_options[:ca_file]).to eql "test_path"
     end
 
     it "Set configuration without loading configuration File" do
@@ -177,11 +177,11 @@ describe PayPal::SDK::Core::Config do
       begin
         Config.configurations = nil
         test_object = TestConfig.new
-        lambda {
+        expect {
           test_object.config
-        }.should raise_error
+        }.to raise_error
         test_object.set_config( :username => "test" )
-        test_object.config.should be_a Config
+        expect(test_object.config).to be_a Config
       ensure
         Config.configurations = backup_configurations
       end

--- a/spec/core/logging_spec.rb
+++ b/spec/core/logging_spec.rb
@@ -15,14 +15,14 @@ describe PayPal::SDK::Core::Logging do
   end
 
   it "get logger object" do
-    @test_logging.logger.should be_a Logger
+    expect(@test_logging.logger).to be_a Logger
   end
 
   it "write message to logger" do
     test_message = "Example log message!!!"
     @test_logging.logger.info(test_message)
     @logger_file.rewind
-    @logger_file.read.should match test_message
+    expect(@logger_file.read).to match test_message
   end
 
 end

--- a/spec/core/openid_connect_spec.rb
+++ b/spec/core/openid_connect_spec.rb
@@ -8,16 +8,16 @@ describe PayPal::SDK::OpenIDConnect do
   end
 
   it "Validate user_agent" do
-    OpenIDConnect::API.user_agent.should match "PayPalSDK/openid-connect-ruby"
+    expect(OpenIDConnect::API.user_agent).to match "PayPalSDK/openid-connect-ruby"
   end
 
   describe "generate_authorize_url" do
 
     it "generate autorize_url" do
       url = OpenIDConnect::Tokeninfo.authorize_url
-      url.should match "client_id=client_id"
-      url.should match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
-      url.should match "scope=openid"
+      expect(url).to match "client_id=client_id"
+      expect(url).to match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
+      expect(url).to match "scope=openid"
     end
 
     describe "sandbox" do
@@ -27,7 +27,7 @@ describe PayPal::SDK::OpenIDConnect do
 
       it "generates a sandbox authorize url" do
         url = OpenIDConnect::Tokeninfo.authorize_url
-        url.should match "sandbox.paypal.com"
+        expect(url).to match "sandbox.paypal.com"
       end
     end
   end
@@ -37,43 +37,43 @@ describe PayPal::SDK::OpenIDConnect do
       :client_id => "new_client_id",
       :redirect_uri => "http://example.com",
       :scope => "openid profile")
-    url.should match "client_id=new_client_id"
-    url.should match Regexp.escape("redirect_uri=#{CGI.escape("http://example.com")}")
-    url.should match Regexp.escape("scope=#{CGI.escape("openid profile")}")
+    expect(url).to match "client_id=new_client_id"
+    expect(url).to match Regexp.escape("redirect_uri=#{CGI.escape("http://example.com")}")
+    expect(url).to match Regexp.escape("scope=#{CGI.escape("openid profile")}")
   end
 
   it "Generate logout_url" do
     url = OpenIDConnect.logout_url
-    url.should match "logout=true"
-    url.should match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
-    url.should_not match "id_token"
+    expect(url).to match "logout=true"
+    expect(url).to match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
+    expect(url).not_to match "id_token"
   end
 
   it "Override logout_url params" do
     url = OpenIDConnect.logout_url({
       :redirect_uri => "http://example.com",
       :id_token  => "testing" })
-    url.should match Regexp.escape("redirect_uri=#{CGI.escape("http://example.com")}")
-    url.should match "id_token=testing"
+    expect(url).to match Regexp.escape("redirect_uri=#{CGI.escape("http://example.com")}")
+    expect(url).to match "id_token=testing"
   end
 
   describe "Validation" do
     it "Create token" do
-      lambda{
+      expect{
         tokeninfo = OpenIDConnect::Tokeninfo.create("invalid-autorize-code")
-      }.should raise_error PayPal::SDK::Core::Exceptions::BadRequest
+      }.to raise_error PayPal::SDK::Core::Exceptions::BadRequest
     end
 
     it "Refresh token" do
-      lambda{
+      expect{
         tokeninfo = OpenIDConnect::Tokeninfo.refresh("invalid-refresh-token")
-      }.should raise_error PayPal::SDK::Core::Exceptions::BadRequest
+      }.to raise_error PayPal::SDK::Core::Exceptions::BadRequest
     end
 
     it "Get userinfo" do
-      lambda{
+      expect{
         userinfo = OpenIDConnect::Userinfo.get("invalid-access-token")
-      }.should raise_error PayPal::SDK::Core::Exceptions::UnauthorizedAccess
+      }.to raise_error PayPal::SDK::Core::Exceptions::UnauthorizedAccess
     end
   end
 
@@ -85,32 +85,32 @@ describe PayPal::SDK::OpenIDConnect do
     end
 
     it "create" do
-      OpenIDConnect::Tokeninfo.api.stub( :post => { :access_token => "access_token" } )
+      allow(OpenIDConnect::Tokeninfo.api).to receive_messages( :post => { :access_token => "access_token" } )
       tokeninfo = OpenIDConnect::Tokeninfo.create("authorize_code")
-      tokeninfo.should be_a OpenIDConnect::Tokeninfo
-      tokeninfo.access_token.should eql "access_token"
+      expect(tokeninfo).to be_a OpenIDConnect::Tokeninfo
+      expect(tokeninfo.access_token).to eql "access_token"
     end
 
     it "refresh" do
-      @tokeninfo.api.stub( :post => { :access_token => "new_access_token" } )
-      @tokeninfo.access_token.should eql "test_access_token"
+      allow(@tokeninfo.api).to receive_messages( :post => { :access_token => "new_access_token" } )
+      expect(@tokeninfo.access_token).to eql "test_access_token"
       @tokeninfo.refresh
-      @tokeninfo.access_token.should eql "new_access_token"
+      expect(@tokeninfo.access_token).to eql "new_access_token"
     end
 
     it "userinfo" do
-      @tokeninfo.api.stub( :post => { :name => "Testing" } )
+      allow(@tokeninfo.api).to receive_messages( :post => { :name => "Testing" } )
       userinfo = @tokeninfo.userinfo
-      userinfo.should be_a OpenIDConnect::Userinfo
-      userinfo.name.should eql "Testing"
+      expect(userinfo).to be_a OpenIDConnect::Userinfo
+      expect(userinfo.name).to eql "Testing"
     end
 
     describe "logout_url" do
       it "Generate logout_url" do
         url = @tokeninfo.logout_url
-        url.should match "id_token=test_id_token"
-        url.should match "logout=true"
-        url.should match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
+        expect(url).to match "id_token=test_id_token"
+        expect(url).to match "logout=true"
+        expect(url).to match Regexp.escape("redirect_uri=#{CGI.escape("http://google.com")}")
       end
 
       describe "sandbox" do
@@ -120,7 +120,7 @@ describe PayPal::SDK::OpenIDConnect do
 
         it "generates a sandbox logout url" do
           url = @tokeninfo.logout_url
-          url.should match "sandbox.paypal.com"
+          expect(url).to match "sandbox.paypal.com"
         end
       end
     end
@@ -128,24 +128,24 @@ describe PayPal::SDK::OpenIDConnect do
 
   describe "Userinfo" do
     it "get" do
-      OpenIDConnect::Userinfo.api.stub( :post => { :name => "Testing" } )
+      allow(OpenIDConnect::Userinfo.api).to receive_messages( :post => { :name => "Testing" } )
 
       userinfo = OpenIDConnect::Userinfo.get("access_token")
       userinfo = OpenIDConnect::Userinfo.new( { :name => "Testing" } )
-      userinfo.should be_a OpenIDConnect::Userinfo
-      userinfo.name.should eql "Testing"
+      expect(userinfo).to be_a OpenIDConnect::Userinfo
+      expect(userinfo.name).to eql "Testing"
 
       userinfo = OpenIDConnect::Userinfo.get( :access_token => "access_token" )
-      userinfo.should be_a OpenIDConnect::Userinfo
-      userinfo.name.should eql "Testing"
+      expect(userinfo).to be_a OpenIDConnect::Userinfo
+      expect(userinfo.name).to eql "Testing"
     end
 
     it "get", :integration => true do
       api = PayPal::SDK::REST::API.new
       access_token = api.token_hash()
       userinfo = OpenIDConnect::Userinfo.get( access_token )
-      userinfo.should be_a OpenIDConnect::Userinfo
-      userinfo.email.should eql "jaypatel512-facilitator@hotmail.com"
+      expect(userinfo).to be_a OpenIDConnect::Userinfo
+      expect(userinfo.email).to eql "jaypatel512-facilitator@hotmail.com"
     end
   end
 

--- a/spec/invoice_examples_spec.rb
+++ b/spec/invoice_examples_spec.rb
@@ -32,7 +32,7 @@ describe "Invoice", :integration => true do
 
   it "get invoice" do
     invoice = PayPal::SDK::REST::Invoice.find("INV2-P6VJ-36HG-BBVT-M2MA")
-    invoice.should be_a PayPal::SDK::REST::Invoice
+    expect(invoice).to be_a PayPal::SDK::REST::Invoice
     expect(invoice.id).to eql "INV2-P6VJ-36HG-BBVT-M2MA"
   end
 end

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -35,7 +35,7 @@ describe "Payments" do
           "description" =>  "This is the payment transaction description." } ] }
 
   it "Validate user-agent", :unit => true do
-    PayPal::SDK::REST::API.user_agent.should match "PayPalSDK/PayPal-Ruby-SDK"
+    expect(PayPal::SDK::REST::API.user_agent).to match "PayPalSDK/PayPal-Ruby-SDK"
   end
 
   describe "Examples" do
@@ -43,9 +43,9 @@ describe "Payments" do
       it "Modifiy global configuration" do
         backup_config = PayPal::SDK::REST.api.config
         PayPal::SDK::REST.set_config( :client_id => "XYZ" )
-        PayPal::SDK::REST.api.config.client_id.should eql "XYZ"
+        expect(PayPal::SDK::REST.api.config.client_id).to eql "XYZ"
         PayPal::SDK::REST.set_config(backup_config)
-        PayPal::SDK::REST.api.config.client_id.should_not eql "XYZ"
+        expect(PayPal::SDK::REST.api.config.client_id).not_to eql "XYZ"
       end
     end
 
@@ -54,53 +54,53 @@ describe "Payments" do
         payment = Payment.new(PaymentAttributes)
         # Create
         payment.create
-        payment.error.should be_nil
-        payment.id.should_not be_nil
+        expect(payment.error).to be_nil
+        expect(payment.id).not_to be_nil
       end
 
       it "Create with request_id" do
         payment = Payment.new(PaymentAttributes)
         payment.create
-        payment.error.should be_nil
+        expect(payment.error).to be_nil
 
         request_id = payment.request_id
 
         new_payment = Payment.new(PaymentAttributes.merge( :request_id => request_id ))
         new_payment.create
-        new_payment.error.should be_nil
+        expect(new_payment.error).to be_nil
 
-        payment.id.should eql new_payment.id
+        expect(payment.id).to eql new_payment.id
 
       end
 
       it "Create with token" do
         api = API.new
         payment = Payment.new(PaymentAttributes.merge( :token => api.token ))
-        Payment.api.should_not eql payment.api
+        expect(Payment.api).not_to eql payment.api
         payment.create
-        payment.error.should be_nil
-        payment.id.should_not be_nil
+        expect(payment.error).to be_nil
+        expect(payment.id).not_to be_nil
       end
 
       it "Create with client_id and client_secret" do
         api = API.new
         payment = Payment.new(PaymentAttributes.merge( :client_id => api.config.client_id, :client_secret => api.config.client_secret))
-        Payment.api.should_not eql payment.api
+        expect(Payment.api).not_to eql payment.api
         payment.create
-        payment.error.should be_nil
-        payment.id.should_not be_nil
+        expect(payment.error).to be_nil
+        expect(payment.id).not_to be_nil
       end
 
       it "List" do
         payment_history = Payment.all( "count" => 5 )
-        payment_history.error.should be_nil
-        payment_history.count.should eql 5
+        expect(payment_history.error).to be_nil
+        expect(payment_history.count).to eql 5
       end
 
       it "Find" do
         payment_history = Payment.all( "count" => 1 )
         payment = Payment.find(payment_history.payments[0].id)
-        payment.error.should be_nil
+        expect(payment.error).to be_nil
       end
 
       describe "Validation", :integration => true do
@@ -111,29 +111,29 @@ describe "Payments" do
         end
 
         it "Find with invalid ID" do
-          lambda {
+          expect {
             payment = Payment.find("Invalid")
-          }.should raise_error PayPal::SDK::Core::Exceptions::ResourceNotFound
+          }.to raise_error PayPal::SDK::Core::Exceptions::ResourceNotFound
         end
 
         it "Find with nil" do
-          lambda{
+          expect{
             payment = Payment.find(nil)
-          }.should raise_error ArgumentError
+          }.to raise_error ArgumentError
         end
 
         it "Find with empty string" do
-          lambda{
+          expect{
             payment = Payment.find("")
-          }.should raise_error ArgumentError
+          }.to raise_error ArgumentError
         end
 
         it "Find record with expired token" do
-          lambda {
+          expect {
             Payment.api.token
             Payment.api.token.sub!(/^/, "Expired")
             Payment.all(:count => 1)
-          }.should_not raise_error
+          }.not_to raise_error
         end
       end
 
@@ -156,8 +156,8 @@ describe "Payments" do
 
         if auth_code != ''
           tokeninfo  = FuturePayment.exch_token(auth_code)
-          tokeninfo.access_token.should_not be_nil
-          tokeninfo.refresh_token.should_not be_nil
+          expect(tokeninfo.access_token).not_to be_nil
+          expect(tokeninfo.refresh_token).not_to be_nil
         end
       end
 
@@ -166,8 +166,8 @@ describe "Payments" do
         correlation_id = '' 
         @future_payment = FuturePayment.new(FuturePaymentAttributes.merge( :token => access_token ))
         @future_payment.create(correlation_id)
-        @future_payment.error.should be_nil
-        @future_payment.id.should_not be_nil
+        expect(@future_payment.error).to be_nil
+        expect(@future_payment.id).not_to be_nil
       end
 
     end
@@ -176,24 +176,24 @@ describe "Payments" do
       before :each do
         @payment = Payment.new(PaymentAttributes)
         @payment.create
-        @payment.should be_success
+        expect(@payment).to be_success
       end
 
       it "Find" do
         sale = Sale.find(@payment.transactions[0].related_resources[0].sale.id)
-        sale.error.should be_nil
-        sale.should be_a Sale
+        expect(sale.error).to be_nil
+        expect(sale).to be_a Sale
       end
 
       describe "instance method" do
         it "Refund" do
           sale   = @payment.transactions[0].related_resources[0].sale
           refund = sale.refund( :amount => { :total => "1.00", :currency => "USD" } )
-          refund.error.should be_nil
+          expect(refund.error).to be_nil
 
           refund = Refund.find(refund.id)
-          refund.error.should be_nil
-          refund.should be_a Refund
+          expect(refund.error).to be_nil
+          expect(refund).to be_a Refund
         end
       end
     end
@@ -244,32 +244,32 @@ describe "Payments" do
       before :each do
         @payment = Payment.new(PaymentAttributes.merge( "intent" => "authorize" ))
         @payment.create
-        @payment.error.should be_nil
+        expect(@payment.error).to be_nil
       end
 
       it "Find" do
         authorize = Authorization.find(@payment.transactions[0].related_resources[0].authorization.id)
-        authorize.error.should be_nil
-        authorize.should be_a Authorization
+        expect(authorize.error).to be_nil
+        expect(authorize).to be_a Authorization
       end
 
       it "Capture" do
         authorize = @payment.transactions[0].related_resources[0].authorization
         capture   = authorize.capture({:amount => { :currency => "USD", :total => "1.00" } })
-        capture.error.should be_nil
+        expect(capture.error).to be_nil
       end
 
       it "Void" do
         authorize = @payment.transactions[0].related_resources[0].authorization
         authorize.void()
-        authorize.error.should be_nil
+        expect(authorize.error).to be_nil
       end
 
      it "Reauthorization" do
         authorize = Authorization.find("7GH53639GA425732B");
         authorize.amount = { :currency => "USD", :total => "1.00" }
         authorize.reauthorize
-        authorize.error.should_not be_nil
+        expect(authorize.error).not_to be_nil
       end
     end
 
@@ -277,21 +277,21 @@ describe "Payments" do
       before :each do
         @payment = Payment.new(PaymentAttributes.merge( "intent" => "authorize" ))
         @payment.create
-        @payment.error.should be_nil
+        expect(@payment.error).to be_nil
         authorize = @payment.transactions[0].related_resources[0].authorization
         @capture = authorize.capture({:amount => { :currency => "USD", :total => "1.00" } })
-        @capture.error.should be_nil
+        expect(@capture.error).to be_nil
       end
 
       it "Find" do
         capture = Capture.find(@capture.id)
-        capture.error.should be_nil
-        capture.should be_a Capture
+        expect(capture.error).to be_nil
+        expect(capture).to be_a Capture
       end
 
       it "Refund" do
         refund = @capture.refund({})
-        refund.error.should be_nil
+        expect(refund.error).to be_nil
       end
     end
 
@@ -309,12 +309,12 @@ describe "Payments" do
             "state" =>  "OH",
             "postal_code" =>  "43210", "country_code" =>  "US" }})
         credit_card.create
-        credit_card.error.should be_nil
-        credit_card.id.should_not be_nil
+        expect(credit_card.error).to be_nil
+        expect(credit_card.id).not_to be_nil
 
         credit_card = CreditCard.find(credit_card.id)
-        credit_card.should be_a CreditCard
-        credit_card.error.should be_nil
+        expect(credit_card).to be_a CreditCard
+        expect(credit_card.error).to be_nil
       end
 
       it "Delete" do
@@ -332,17 +332,17 @@ describe "Payments" do
             "type" =>  "visa",
             "number" =>  "4111111111111111" })
           credit_card.create
-          credit_card.error.should_not be_nil
+          expect(credit_card.error).not_to be_nil
 
-          credit_card.error.name.should eql "VALIDATION_ERROR"
-          credit_card.error["name"].should eql "VALIDATION_ERROR"
+          expect(credit_card.error.name).to eql "VALIDATION_ERROR"
+          expect(credit_card.error["name"]).to eql "VALIDATION_ERROR"
 
-          credit_card.error.details[0].field.should eql "expire_year"
-          credit_card.error.details[0].issue.should eql "Required field missing"
-          credit_card.error.details[1].field.should eql "expire_month"
-          credit_card.error.details[1].issue.should eql "Required field missing"
+          expect(credit_card.error.details[0].field).to eql "expire_year"
+          expect(credit_card.error.details[0].issue).to eql "Required field missing"
+          expect(credit_card.error.details[1].field).to eql "expire_month"
+          expect(credit_card.error.details[1].issue).to eql "Required field missing"
 
-          credit_card.error["details"][0]["issue"].should eql "Required field missing"
+          expect(credit_card.error["details"][0]["issue"]).to eql "Required field missing"
         end
       end
     end

--- a/spec/subscription_examples_spec.rb
+++ b/spec/subscription_examples_spec.rb
@@ -69,13 +69,13 @@ describe "Subscription" do
       # create access token and then create a plan
       $api = API.new
       plan = Plan.new(PlanAttributes.merge( :token => $api.token ))
-      Plan.api.should_not eql plan.api
+      expect(Plan.api).not_to eql plan.api
       plan.create
 
       # make sure the transaction was successful
       $plan_id = plan.id
-      plan.error.should be_nil
-      plan.id.should_not be_nil
+      expect(plan.error).to be_nil
+      expect(plan.id).not_to be_nil
     end
 
     it "Update" do
@@ -96,8 +96,8 @@ describe "Subscription" do
     it "List" do
       # list all billing plans
       plan_list = Plan.all
-      plan_list.error.should be_nil
-      plan_list.plans.count.should > 1
+      expect(plan_list.error).to be_nil
+      expect(plan_list.plans.count).to be > 1
     end
 
     it "Delete" do
@@ -117,7 +117,7 @@ describe "Subscription" do
 
       # make sure the plan has been deleted
       plan = Plan.find(plan_id)
-      plan.id.should_not eq plan_id
+      expect(plan.id).not_to eq plan_id
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 3.1.2 with the following command:
    transpec

* 171 conversions
    from: obj.should
      to: expect(obj).to

* 24 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 15 conversions
    from: lambda { }.should
      to: expect { }.to

* 4 conversions
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

* 3 conversions
    from: lambda { }.should_not
      to: expect { }.not_to

* 1 conversion
    from: > expected
      to: be > expected

For more details: https://github.com/yujinakayama/transpec#supported-conversions