### PR TITLE
Parse refunded_amount for Invoice resources.

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1074,6 +1074,12 @@ module PayPal::SDK
         end
       end
 
+      class InvoiceAmountWrapper < Base
+        def self.load_members
+          object_of :paypal, Currency
+        end
+      end
+
       class Invoice < Base
         def self.load_members
           object_of :id, String
@@ -1093,6 +1099,7 @@ module PayPal::SDK
           object_of :tax_inclusive, Boolean
           object_of :terms, String
           object_of :note, String
+          object_of :refunded_amount, InvoiceAmountWrapper
           object_of :merchant_memo, String
           object_of :logo_url, String
           object_of :total_amount, Currency


### PR DESCRIPTION
I needed to add this so I might as well submit it here. I don't know how to hide this indirection where refunded amount has structure: `{"paypal": {"currency": "USD", "amount": "100.00"}}`