### PR TITLE
Fixed patch_requests by Array in update method of CreditCard

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -323,11 +323,14 @@ module PayPal::SDK
           success?
         end
 
-        def update(patch)
-          patch = Patch.new(patch) unless patch.is_a? Patch
-          patch_request = Array.new(1, patch.to_hash)
+        def update(patch_requests)
+          patch_request_array = []
+          patch_requests.each do |patch_request|
+            patch_request = Patch.new(patch_request) unless patch_request.is_a? Patch
+            patch_request_array << patch_request.to_hash
+          end
           path = "v1/vault/credit-cards/#{self.id}"
-          response = api.patch(path, patch_request, http_header)
+          response = api.patch(path, patch_request_array, http_header)
           self.merge!(response)
           success?
         end

--- a/samples/credit_card/update.rb
+++ b/samples/credit_card/update.rb
@@ -33,17 +33,29 @@ include PayPal::SDK::Core::Logging
      :postal_code => "43210",
      :country_code => "US" }})
 
-@updated_card = {
-  :op=> "replace",
-  :path=> "/billing_address",
-  :value=> {
-    "line1": "111 First Street",
-    "city": "Saratoga",
-    "country_code": "US",
-    "state": "CA",
-    "postal_code": "95070"
+@patch_requests = [
+  {
+    :op => "replace",
+    :path => "/billing_address",
+    :value => {
+      "line1": "111 First Street",
+      "city": "Saratoga",
+      "country_code": "US",
+      "state": "CA",
+      "postal_code": "95070"
+    }
+  },
+  {
+    :op => "replace",
+    :path => "/first_name",
+    :value => "Mary"
+  },
+  {
+    :op => "replace",
+    :path => "/last_name",
+    :value => "Shopper"
   }
-}
+]
 
 # Make API call & get response status
 # ###Save
@@ -53,8 +65,7 @@ if @credit_card.create
   logger.info "CreditCard[#{@credit_card.id}] created successfully"
 
   # update the newly created credit card
-  patch_request = Patch.new(@updated_card)
-  if @credit_card.update(patch_request)
+  if @credit_card.update(@patch_requests)
     logger.info "CreditCard[#{@credit_card.id}] updated successfully"
   else
     logger.error "Error while updating CreditCard:"


### PR DESCRIPTION
The old update method only can update [one patch object](https://github.com/paypal/PayPal-Ruby-SDK/blob/0252a5c879195cd5750425b5242e7f53efd73cbb/lib/paypal-sdk/rest/data_types.rb#L326-L333).
This change will permit to update more than one patch object [like this](https://github.com/paypal/PayPal-Ruby-SDK/blob/0252a5c879195cd5750425b5242e7f53efd73cbb/lib/paypal-sdk/rest/data_types.rb#L75-L85).