### PR TITLE
Enabled Custom Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 PayPal Node SDK release notes
 =============================
 
+1.4.5
+------
+  * Enable Passing Custom Headers [#197](https://github.com/paypal/PayPal-Ruby-SDK/pull/197)
+
 1.4.4
 ------
   * Update on Invoicing API changes [#189](https://github.com/paypal/PayPal-Ruby-SDK/pull/189)


### PR DESCRIPTION
Now, the custom headers can be added as shown:

```ruby
@credit_card = CreditCard.new({
   ....
   :type => "visa",
   :number => "4567516310777851",
   :expire_month => "11",
   ...   
})

@credit_card.header = {
  "PayPal-Partner-Attribution-Id" => "123123123"
}
```