### PR TITLE
Two convenience methods for Payment class

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -92,6 +92,18 @@ module PayPal::SDK
           success?
         end
 
+        def approval_url(immediate = false)
+          link = links.detect { |l| l.rel == 'approval_url' }
+          return nil unless link
+          link.href + (immediate ? '&useraction=commit' : '')
+        end
+
+        def token
+          url = approval_url
+          return nil unless url
+          CGI.parse(URI.parse(url).query)['token'].first
+        end
+
         class << self
           def find(resource_id)
             raise ArgumentError.new("id required") if resource_id.to_s.strip.empty?


### PR DESCRIPTION
Proposed methods:

1) `Payment#approval_url`. Reason: for most straightforward "accept payment" flow, there is pretty tiresome code should be written each time:
```ruby
#...
payment.create
redirect_to payment.links.detect { |l| l.rel == 'approval_url' }.href
# or, for immediate payment:
redirect_to payment.links.detect { |l| l.rel == 'approval_url' }.href + '&useraction=commit'
```
With this proposal, they turn into:
```ruby
redirect_to payment.approval_url
redirect_to payment.approval_url(true)
```

2) `Payment#token`. Reason: the only method to identify payment in cancel action is remeber the token received after payment create (discussed here: https://github.com/paypal/PayPal-Ruby-SDK/issues/119#issuecomment-143798419). Extracting this token every time is a dirty task.

There are no tests for two new methods: I'm not sure where it would be appropriate to place them. Recommendations are welcome.