### PR TITLE
updating the data_types.rb adding the "billing_plan_units"

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -51,6 +51,7 @@ module PayPal::SDK
           array_of  :failed_transactions, Error
           object_of :payment_instruction, PaymentInstruction
           object_of :state, String
+          object_of :billing_plan_units, String
           object_of :experience_profile_id, String
           object_of :redirect_urls, RedirectUrls
           object_of :create_time, String


### PR DESCRIPTION
Adding the method "billing_plan_units" inside data_types.rb file, this is necessary to resolve the bug "undefined method billing_plan_units" after to pay with paypal using this gem.
