### PR TITLE
Use UTF8 always as charset to do a CRC32 checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 PayPal Ruby SDK release notes
 =============================
 
+TODO
+------
+  * Use UTF-8 as the character set when generating CRC32 checksum when validating webhook events
+
 v1.4.7
 ------
   * Enabled third party invoicing for all invoicing API operations [#209](https://github.com/paypal/PayPal-Ruby-SDK/pull/209)

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1300,7 +1300,8 @@ module PayPal::SDK
           end
 
           def get_expected_sig(transmission_id, timestamp, webhook_id, event_body)
-            crc = Zlib::crc32(event_body).to_s
+            utf8_encoded_event_body = event_body.encode("UTF-8")
+            crc = Zlib::crc32(utf8_encoded_event_body).to_s
             transmission_id + "|" + timestamp + "|" + webhook_id + "|" + crc
           end
 


### PR DESCRIPTION
- When doing webhook validation, the content should be UTF-8 encoded
  when generating the signature