### PR TITLE
Add (optional) exception raising on API errors

### DIFF
--- a/lib/paypal-sdk/core/exceptions.rb
+++ b/lib/paypal-sdk/core/exceptions.rb
@@ -94,5 +94,15 @@ module PayPal::SDK::Core
         @response['Allow'].split(',').map { |verb| verb.strip.downcase.to_sym }
       end
     end
+
+    # API error: returned as 200 + "error" key in response.
+    class UnsuccessfulApiCall < RuntimeError
+      attr_reader :api_error
+
+      def initialize(api_error)
+        super(api_error['message'])
+        @api_error = api_error
+      end
+    end
   end
 end

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -33,7 +33,19 @@ module PayPal::SDK
           super
         end
 
+        def raise_error!
+          raise Core::Exceptions::UnsuccessfulApiCall, error if error
+        end
+
         def self.load_members
+        end
+
+        def self.raise_on_api_error(*methods)
+          methods.each do |symbol|
+            define_method("#{symbol}!") {|*arg|
+              raise_error! unless send(symbol, *arg)
+            }
+          end
         end
 
         class Number < Float
@@ -91,6 +103,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :create, :update, :execute
 
         def approval_url(immediate = false)
           link = links.detect { |l| l.rel == 'approval_url' }
@@ -257,6 +271,8 @@ module PayPal::SDK
           success?
         end
 
+        raise_on_api_error :create
+
         class << self
 
           def exch_token(auth_code)
@@ -346,6 +362,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :create, :update, :delete
       end
 
       class Address < Base
@@ -458,6 +476,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :create, :update, :delete
       end
 
       class ExtendedBankAccount < BankAccount
@@ -851,6 +871,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :capture, :void, :reauthorize
       end
 
       class Order < Base
@@ -900,6 +922,8 @@ module PayPal::SDK
           response = api.post(path, self.to_hash, http_header)
           Authorization.new(response)
         end
+
+        raise_on_api_error :capture, :void, :authorize
       end
 
       class Capture < Base
@@ -1186,6 +1210,10 @@ module PayPal::SDK
           success?
         end
 
+        raise_on_api_error :create, :send_invoice, :remind, :cancel,
+                           :record_payment, :record_refund, :update, :delete
+
+
         #
         class << self
           def search(options, access_token = nil)
@@ -1395,6 +1423,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :update, :delete
 
         class << self
           def get(webhook_id)
@@ -1785,6 +1815,8 @@ module PayPal::SDK
           success?
         end
 
+        raise_on_api_error :create, :update
+
         class << self
           def find(resource_id)
             raise ArgumentError.new("id required") if resource_id.to_s.strip.empty?
@@ -2002,6 +2034,9 @@ module PayPal::SDK
           success?
         end
 
+        raise_on_api_error :create, :execute, :update, :suspend, :re_activate,
+                           :cancel, :bill_balance, :set_balance
+
         class << self
           def transactions(agreement_id, start_date, end_date, options = {})
             path = "v1/payments/billing-agreements/#{agreement_id}/transactions" #?start-date=#{start_date}&end-date=#{end_date}"
@@ -2107,6 +2142,8 @@ module PayPal::SDK
           self.merge!(response)
           success?
         end
+
+        raise_on_api_error :update, :partial_update, :delete
 
         class << self
           def find(resource_id)

--- a/spec/rest/data_types_spec.rb
+++ b/spec/rest/data_types_spec.rb
@@ -1,0 +1,62 @@
+module PayPal::SDK::REST::DataTypes
+  describe Base do
+    let(:error_object) {
+      {
+        "name" => "INVALID_EXPERIENCE_PROFILE_ID",
+        "message" => "The requested experience profile ID was not found",
+        "information_link" => "https://developer.paypal.com/docs/api/#INVALID_EXPERIENCE_PROFILE_ID",
+        "debug_id" => "1562931a79fd2"
+      }
+    }
+
+    context '#raise_error!' do
+      context 'when there is error' do
+        subject { described_class.new(error: error_object) }
+
+        it 'raises error on request with all API information' do
+          expect { subject.raise_error! }
+            .to raise_error { |err|
+              expect(err).to be_a(PayPal::SDK::Core::Exceptions::UnsuccessfulApiCall)
+              expect(err.message).to eq("The requested experience profile ID was not found")
+              expect(err.api_error).to eq(error_object)
+            }
+        end
+      end
+
+      context 'when there is no error' do
+        subject { described_class.new(error: nil) }
+
+        it { expect { subject.raise_error! }.not_to raise_error }
+      end
+    end
+
+    context '.raise_on_api_error' do
+      let(:klass) {
+        Class.new(described_class) do
+          def some_call
+          end
+
+          raise_on_api_error :some_call
+        end
+      }
+
+      subject { klass.new }
+
+      context 'when call is successful' do
+        before {
+          expect(subject).to receive(:some_call).and_return(true)
+        }
+        it { expect { subject.some_call! }.not_to raise_error }
+      end
+
+      context 'when call is unsuccessful' do
+        before {
+          expect(subject).to receive(:some_call).and_return(false)
+          expect(subject).to receive(:error).twice.and_return(error_object)
+        }
+
+        it { expect { subject.some_call! }.to raise_error(PayPal::SDK::Core::Exceptions::UnsuccessfulApiCall) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
It PR is trying to unify two ways errors could be raised while using the gem:

1. If there is some authentication or network error, there would be an exception.
2. If there is logic error (like not enough parameters/wrong parameters for call), there would be `false` returned from method, and `api_object.error` field filled.

In most of code, we'd like to have a friendly exception for both.

Showcase:

```ruby
# Before this PR:
payment = PayPal::REST::Payment.new(...)
if !payment.create # API call unsuccessful
  error = payment.error
  # do something with error
end

# After this PR:
# 1. basic error raising helper:
payment.create
payment.raise_error! # raises Core::Exceptions::UnsuccessfulApiCall IF there was error on `payment`

# 2. new "bang" methods:
payment.create! # calls `create` and raises Core::Exceptions::UnsuccessfulApiCall if it was not successful
```

Some notes:
* the bang wrapper was added only for methods explicitly returning result of `success?` call (and not for Authorization#capture, for example), don't know if it is sane;
* as far as I can understand, there is also **third** way of failure -- when payment execution is failed, there is NO `error` object, but `payment.state == failed` and `payment.failure_reason`. This is not in a scope of current PR.