### PR TITLE
Use String.force_encoding to force conversion to UTF-8

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1328,7 +1328,7 @@ module PayPal::SDK
           end
 
           def get_expected_sig(transmission_id, timestamp, webhook_id, event_body)
-            utf8_encoded_event_body = event_body.encode("UTF-8")
+            utf8_encoded_event_body = event_body.force_encoding("UTF-8")
             crc = Zlib::crc32(utf8_encoded_event_body).to_s
             transmission_id + "|" + timestamp + "|" + webhook_id + "|" + crc
           end


### PR DESCRIPTION
This should fix the issue with character encoding failing.

- Encode may fail. See:
  https://github.com/paypal/PayPal-Ruby-SDK/pull/215#issuecomment-235867531
  Thanks to SeTeM for reporting the issue.

```
irb(main):024:0> s = ""
=> ""
irb(main):025:0> s = s.encode("ASCII")
=> ""
irb(main):026:0> s.encoding
=> #<Encoding:US-ASCII>
irb(main):027:0> s << 0xD0
=> "\xD0"
irb(main):028:0> s.encoding
=> #<Encoding:ASCII-8BIT>
irb(main):029:0> s.encode("UTF-8")
Encoding::UndefinedConversionError: "\xD0" from ASCII-8BIT to UTF-8
	from (irb):29:in `encode'
	from (irb):29
	from /Users/brluk/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
irb(main):030:0> s.force_encoding("UTF-8")
=> "\xD0"
irb(main):031:0> s.encoding
=> #<Encoding:UTF-8>
```