### PR TITLE
Ensure Webhooks event digest algorithm is supported by OpenSSL

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1342,6 +1342,7 @@ module PayPal::SDK
           def verify_signature(transmission_id, timestamp, webhook_id, event_body, cert, actual_sig_encoded, algo)
             expected_sig = get_expected_sig(transmission_id, timestamp, webhook_id, event_body)
 
+            algo = algo.sub(/withRSA/i, "")
             digest = OpenSSL::Digest.new(algo)
             digest.update(expected_sig)
             actual_sig = Base64.decode64(actual_sig_encoded).force_encoding('UTF-8')

--- a/spec/webhooks_examples_spec.rb
+++ b/spec/webhooks_examples_spec.rb
@@ -50,6 +50,7 @@ describe "Webhooks" do
     actual_signature = "thy4/U002quzxFavHPwbfJGcc46E8rc5jzgyeafWm5mICTBdY/8rl7WJpn8JA0GKA+oDTPsSruqusw+XXg5RLAP7ip53Euh9Xu3UbUhQFX7UgwzE2FeYoY6lyRMiiiQLzy9BvHfIzNIVhPad4KnC339dr6y2l+mN8ALgI4GCdIh3/SoJO5wE64Bh/ueWtt8EVuvsvXfda2Le5a2TrOI9vLEzsm9GS79hAR/5oLexNz8UiZr045Mr5ObroH4w4oNfmkTaDk9Rj0G19uvISs5QzgmBpauKr7Nw++JI0pr/v5mFctQkoWJSGfBGzPRXawrvIIVHQ9Wer48GR2g9ZiApWg=="
     event_body = '{"id":"WH-0G2756385H040842W-5Y612302CV158622M","create_time":"2015-05-18T15:45:13Z","resource_type":"sale","event_type":"PAYMENT.SALE.COMPLETED","summary":"Payment completed for $ 20.0 USD","resource":{"id":"4EU7004268015634R","create_time":"2015-05-18T15:44:02Z","update_time":"2015-05-18T15:44:21Z","amount":{"total":"20.00","currency":"USD"},"payment_mode":"INSTANT_TRANSFER","state":"completed","protection_eligibility":"ELIGIBLE","protection_eligibility_type":"ITEM_NOT_RECEIVED_ELIGIBLE,UNAUTHORIZED_PAYMENT_ELIGIBLE","parent_payment":"PAY-86C81811X5228590KKVNARQQ","transaction_fee":{"value":"0.88","currency":"USD"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/sale/4EU7004268015634R","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/sale/4EU7004268015634R/refund","rel":"refund","method":"POST"},{"href":"https://api.sandbox.paypal.com/v1/payments/payment/PAY-86C81811X5228590KKVNARQQ","rel":"parent_payment","method":"GET"}]},"links":[{"href":"https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-0G2756385H040842W-5Y612302CV158622M","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-0G2756385H040842W-5Y612302CV158622M/resend","rel":"resend","method":"POST"}]}'
     cert_url = "https://api.sandbox.paypal.com/v1/notifications/certs/CERT-360caa42-fca2a594-a5cafa77"
+    algo = "SHA256withRSA"
 
     it "verify common name" do
       cert = PayPal::SDK::REST::WebhookEvent.get_cert(cert_url)
@@ -76,10 +77,10 @@ describe "Webhooks" do
     end
 
     it "verify" do
-      valid = PayPal::SDK::REST::WebhookEvent.verify(transmission_id, timestamp, webhook_id, event_body, cert_url, actual_signature)
+      valid = PayPal::SDK::REST::WebhookEvent.verify(transmission_id, timestamp, webhook_id, event_body, cert_url, actual_signature, algo)
       expect(valid).to be_truthy
     end
-  end
 
+  end
 
 end


### PR DESCRIPTION
This is a fix for #205 based on suggestions from @jaypatel512. It's a simple string substitution that will account for this issue, and hopefully any similar issues with SHA* digest algorithms in the future should the webhooks api change.

Keep in mind supported OpenSSL digest algorithm values are: `dgst, sha, sha1, mdc2, ripemd160, sha224, sha256, sha384, sha512, md4, md5, blake2b, blake2s`

Also updated the integration test for verifying webhooks events.