### PR TITLE
Fixed serious bug stopping 400 Bad Request responses from raising error

### DIFF
--- a/lib/paypal-sdk/core/util/http_helper.rb
+++ b/lib/paypal-sdk/core/util/http_helper.rb
@@ -129,7 +129,7 @@ module PayPal::SDK::Core
         case response.code.to_i
           when 301, 302, 303, 307
             raise(Redirection.new(response))
-          when 200...400
+          when 200...399
             response
           when 400
             raise(BadRequest.new(response))


### PR DESCRIPTION
The case statement was misconstructed and was not capturing 400 Bad Request errors