### PR TITLE
Flatten error hashes in #formatResponse to prevent in send() Fixes #234

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rake', :require => false
 group :test do
   gem 'simplecov', :require => false
   gem 'rspec'
+  gem 'webmock'
 end
 
 gem 'releasinator', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,14 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (>= 1.6.0, < 2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     github-markup (1.4.0)
+    hashdiff (0.3.0)
     json (1.8.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -49,6 +52,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
@@ -65,6 +69,10 @@ GEM
     vandamme (0.0.11)
       github-markup (~> 1.3)
       redcarpet (~> 3.3.2)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xml-simple (1.1.5)
 
 PLATFORMS
@@ -77,6 +85,7 @@ DEPENDENCIES
   releasinator (~> 0.6)
   rspec
   simplecov
+  webmock
 
 BUNDLED WITH
    1.13.1

--- a/lib/paypal-sdk/core/api/rest.rb
+++ b/lib/paypal-sdk/core/api/rest.rb
@@ -143,12 +143,24 @@ module PayPal::SDK::Core
           if response.code >= "200" and response.code <= "299"
             response.body && response.content_type == "application/json" ? MultiJson.load(response.body) : {}
           elsif response.content_type == "application/json"
-            { "error" => MultiJson.load(response.body) }
+            { "error" => flat_hash(MultiJson.load(response.body)) }
           else
             { "error" => { "name" => response.code, "message" => response.message,
               "developer_msg" => response } }
           end
         payload
+      end
+
+      def flat_hash(h)
+        new_hash = {}
+        h.each_pair do |key, val|
+          if val.is_a?(Hash)
+            new_hash.merge!(flat_hash(val))
+          else
+            new_hash[key] = val
+          end
+        end
+        new_hash
       end
 
       # Log PayPal-Request-Id header

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,3 +33,5 @@ RSpec.configure do |config|
   config.include SampleData
   # config.include PayPal::SDK::REST::DataTypes
 end
+
+WebMock.allow_net_connect!


### PR DESCRIPTION
This was a fun one. Hashes containing nested hashes used in calls to [`send`](https://github.com/paypal/PayPal-Ruby-SDK/blob/master/lib/paypal-sdk/core/api/data_types/base.rb#L137) will fail, for reasons mostly unbeknownst to me, but I'm guessing because of the internals of ruby message passing don't know what to do with those internal hashes.

Point being, if the error response is a json response with a nested object, then we'll never be able to assign an error value to `self`, causing `.success?` to return `true` even if there was an error in the response.

See #234