### PR TITLE
Remove the unused security_test_sandbox

### DIFF
--- a/lib/paypal-sdk/core/api/rest.rb
+++ b/lib/paypal-sdk/core/api/rest.rb
@@ -14,7 +14,6 @@ module PayPal::SDK::Core
       DEFAULT_REST_END_POINTS = {
         :sandbox => "https://api.sandbox.paypal.com",
         :live    => "https://api.paypal.com",
-        :security_test_sandbox   => "https://test-api.sandbox.paypal.com"
       }
       TOKEN_REQUEST_PARAMS = "grant_type=client_credentials"
 


### PR DESCRIPTION
- api.sandbox.paypal.com accepts TLS 1.2 connections and can be used
  to test.