### PR TITLE
Add method authorize for Order with amount parameter

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -937,6 +937,12 @@ module PayPal::SDK
           Authorization.new(response)
         end
 
+        def authorize(amount, currency)
+          path = "v1/payments/orders/#{self.id}/authorize"
+          response = api.post(path, self.to_hash.merge(amount: {total: amount.to_s, currency: currency} ), http_header)
+          Authorization.new(response)
+        end
+
         raise_on_api_error :capture, :void, :authorize
       end
 


### PR DESCRIPTION
To reflect the following API call - https://developer.paypal.com/docs/api/payments/#order_authorize
I'm not sure how to add a test/sample for its in a better way