### PR TITLE
WebhookEvent doesn't respond to `find` and `all` methods

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1594,17 +1594,15 @@ module PayPal::SDK
             WebhookEvent.find(webhook_event_id)
           end
 
-          class << self
-            def find(resource_id)
-              raise ArgumentError.new("webhook_event_id required") if resource_id.to_s.strip.empty?
-              path = "v1/notifications/webhooks-events/#{resource_id}"
-              self.new(api.get(path))
-            end
+          def find(resource_id)
+            raise ArgumentError.new("webhook_event_id required") if resource_id.to_s.strip.empty?
+            path = "v1/notifications/webhooks-events/#{resource_id}"
+            self.new(api.get(path))
+          end
 
-            def all(options = {})
-              path = "v1/notifications/webhooks-events"
-              WebhookEventList.new(api.get(path, options))
-            end
+          def all(options = {})
+            path = "v1/notifications/webhooks-events"
+            WebhookEventList.new(api.get(path, options))
           end
         end
       end

--- a/spec/webhooks_examples_spec.rb
+++ b/spec/webhooks_examples_spec.rb
@@ -15,6 +15,14 @@ describe "Webhooks" do
     ]
   }
 
+  describe "PayPal::SDK::Core::API::DataTypes::WebhookEvent" do
+    describe "get event by id via .find" do
+      it "exists" do
+        expect(WebhookEvent).to respond_to(:find)
+      end
+    end
+  end
+
   describe "Notifications", :integration => true do
     it "create webhook" do
       $webhook = PayPal::SDK::REST::Webhook.new(webhookAttributes)


### PR DESCRIPTION
I was trying to load a `WebhookEvent` by an id via the REST API, but it seemed that it doesn't respond to `.find` nor `.all` methods. And the reason is because these methods were defined in `class << self` block nested in another `class << self` probably by mistake.

It's my first time contributing to this repo, so feel free to comment on code style and specs. I didn't know how to make more complicated tests cases, but I feel like simply accepting that object responds to this method should work.