### PR TITLE
Bugfix in ErrorHash.convert with nested hashes

### DIFF
--- a/lib/paypal-sdk/rest/error_hash.rb
+++ b/lib/paypal-sdk/rest/error_hash.rb
@@ -13,7 +13,7 @@ module PayPal
         def []=(key, value)
           value =
             if value.is_a? Hash
-              ErrorHash.convert(hash)
+              ErrorHash.convert(value)
             elsif value.is_a? Array and value[0].is_a? Hash
               value.map{|array_value| ErrorHash.convert(array_value) }
             else

--- a/spec/rest/error_hash_spec.rb
+++ b/spec/rest/error_hash_spec.rb
@@ -24,7 +24,7 @@ module PayPal::SDK::REST
     end
 
     it 'can access string keys as properties, strings, or symbols' do
-      hash = ErrorHash.convert({ 'foo': 5 })
+      hash = ErrorHash.convert({ 'foo' => 5 })
       hash['boo'] = 'grue'
 
       expect(hash.foo).to eq(5)

--- a/spec/rest/error_hash_spec.rb
+++ b/spec/rest/error_hash_spec.rb
@@ -1,0 +1,83 @@
+module PayPal::SDK::REST
+  describe ErrorHash do
+    it 'converts Hashes to ErrorHashes' do
+      hash = ErrorHash.convert({
+        nested_hash: { bing: 'bong' },
+        empty_array: [],
+        array_with_hashes: [
+          { foo: 'boo' },
+          { biz: 'boz' }
+        ],
+        array_without_hashes: [1, 2, 3],
+        nilly: nil,
+        stringy: 'cheese'
+      })
+
+      expect(hash).to be_a(ErrorHash)
+      expect(hash.nested_hash).to be_a(ErrorHash)
+      expect(hash.empty_array).to eq([])
+      expect(hash.array_with_hashes[0]).to be_a(ErrorHash)
+      expect(hash.array_with_hashes[1]).to be_a(ErrorHash)
+      expect(hash.array_without_hashes).to eq([1, 2, 3])
+      expect(hash.nilly).to be_nil
+      expect(hash.stringy).to eq('cheese')
+    end
+
+    it 'can access string keys as properties, strings, or symbols' do
+      hash = ErrorHash.convert({ 'foo': 5 })
+      hash['boo'] = 'grue'
+
+      expect(hash.foo).to eq(5)
+      expect(hash['foo']).to eq(5)
+      expect(hash[:foo]).to eq(5)
+      expect(hash.boo).to eq('grue')
+      expect(hash['boo']).to eq('grue')
+      expect(hash[:boo]).to eq('grue')
+    end
+
+    it 'can access symbol keys as properties, strings, or symbols' do
+      hash = ErrorHash.convert({ :foo => 5 })
+      hash[:boo] = 'grue'
+
+      expect(hash.foo).to eq(5)
+      expect(hash['foo']).to eq(5)
+      expect(hash[:foo]).to eq(5)
+      expect(hash.boo).to eq('grue')
+      expect(hash['boo']).to eq('grue')
+      expect(hash[:boo]).to eq('grue')
+    end
+
+    it 'converts Hashes to ErrorHashes on assignment' do
+      hash = ErrorHash.new
+      hash['foo'] = { bing: 'bong' }
+
+      expect(hash['foo']).to be_a(ErrorHash)
+      expect(hash['foo'].bing).to eq('bong')
+    end
+
+    it 'converts Hashes inside of Arrays to ErrorHashes on assignment' do
+      hash = ErrorHash.new
+      hash['foo'] = [{ bing: 'bong' }]
+
+      expect(hash['foo'][0]).to be_a(ErrorHash)
+      expect(hash['foo'][0].bing).to eq('bong')
+    end
+
+    it "doesn't convert Hashes inside of Arrays if the first element of the array isn't a Hash" do
+      hash = ErrorHash.new
+      hash['foo'] = [100, { bing: 'bong' }]
+
+      expect(hash['foo'][1]).to be_a(Hash)
+      expect(hash['foo'][1]).not_to be_a(ErrorHash)
+    end
+
+    it 'gets and sets numbers and strings' do
+      hash = ErrorHash.new
+      hash['foo'] = 123
+      hash['boo'] = 'baa'
+
+      expect(hash['foo']).to eq(123)
+      expect(hash['boo']).to eq('baa')
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug with nested hashes in `ErrorHash.convert`, reported in issue #257.

This also adds several tests for the `ErrorHash` class because there weren't any before.