### PR TITLE
Pass auth-assertion header in request for third party call

### DIFF
--- a/lib/paypal-sdk/core/api/rest.rb
+++ b/lib/paypal-sdk/core/api/rest.rb
@@ -164,6 +164,34 @@ module PayPal::SDK::Core
         new_hash
       end
 
+      # Generate paypal auth-assertion-header
+      def auth_assertion_header(id=nil, is_payer_id=false, alg=nil, kid= nil)
+        header = {
+          "alg" => "none"
+        }
+        if alg != nil
+          header = {
+            "alg" => alg,
+            "kid" => kid
+          }
+        end
+        if is_payer_id == false
+          body = { "email" => id,
+                    "iss" => config.client_id
+                 }
+        else
+          body = { "payer_id" => id,
+                    "iss" => config.client_id
+                 }
+        end
+        encodedHeader = Base64.encode64(header.to_json.to_s.force_encoding('UTF-8')).gsub!(/\n/, "")
+        encodedBody = Base64.encode64(body.to_json.to_s.force_encoding('UTF-8')).gsub!(/\n/, "")
+        @auth_header = "#{encodedHeader}.#{encodedBody}."
+        logger.info "auth_header: #{@auth_header}"
+        return @auth_header
+      end
+      attr_writer :auth_assertion_header
+
       # Log PayPal-Request-Id header
       def log_http_call(payload)
         if payload[:header] and payload[:header]["PayPal-Request-Id"]

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -9,7 +9,7 @@ module PayPal::SDK
   module REST
     module DataTypes
       class Base < Core::API::DataTypes::Base
-        attr_accessor :error
+        attr_accessor :error, :auth_header
         attr_writer   :header, :request_id
 
         def header
@@ -21,7 +21,11 @@ module PayPal::SDK
         end
 
         def http_header
-          { "PayPal-Request-Id" => request_id.to_s }.merge(header)
+          @auth_assertion_header = {}
+          if auth_header != nil
+            @auth_assertion_header = {"PayPal-Auth-Assertion" => auth_header.to_s}
+          end
+          { "PayPal-Request-Id" => request_id.to_s}.merge(@auth_assertion_header).merge(header)
         end
 
         def success?
@@ -814,6 +818,7 @@ module PayPal::SDK
         end
 
         def refund(refund)
+          @auth_header = refund[:auth_header]
           refund = Refund.new(refund) unless refund.is_a? Refund
           path = "v1/payments/sale/#{self.id}/refund"
           response = api.post(path, refund.to_hash, http_header)
@@ -821,6 +826,7 @@ module PayPal::SDK
         end
 
         def refund_request(refund_request)
+          @auth_header = refund_request[:auth_header]
           refund_request = RefundRequest.new(refund_request) unless refund_request.is_a? RefundRequest
           path = "v1/payments/sale/#{self.id}/refund"
           response = api.post(path, refund_request.to_hash, http_header)
@@ -967,6 +973,7 @@ module PayPal::SDK
 
         # Deprecated - please use refund_request
         def refund(refund)
+          @auth_header = refund[:auth_header]
           refund = Refund.new(refund) unless refund.is_a? Refund
           path = "v1/payments/capture/#{self.id}/refund"
           response = api.post(path, refund.to_hash, http_header)
@@ -974,6 +981,7 @@ module PayPal::SDK
         end
 
         def refund_request(refund_request)
+          @auth_header = refund_request[:auth_header]
           refund_request = RefundRequest.new(refund_request) unless refund_request.is_a? RefundRequest
           path = "v1/payments/capture/#{self.id}/refund"
           response = api.post(path, refund_request.to_hash, http_header)

--- a/spec/core/openid_connect_spec.rb
+++ b/spec/core/openid_connect_spec.rb
@@ -149,5 +149,35 @@ describe PayPal::SDK::OpenIDConnect do
     end
   end
 
+  describe "auth_assertion_header" do
+      it "generate an auth assertion header" do
+        alg = {"alg":"none"}
+        api = PayPal::SDK::REST::API.new
+        auth_assertion = api.auth_assertion_header()
+        expect(Base64.decode64(auth_assertion).force_encoding('UTF-8')).to match alg.to_json
+      end
+
+      it "generate an auth assertion header with email" do
+        alg = {"alg":"none"}
+        payload = {"email":"test@paypal.com", "iss":"AYSq3RDGsmBLJE-otTkBtM-jBRd1TCQwFf9RGfwddNXWz0uFU9ztymylOhRS"}
+        api = PayPal::SDK::REST::API.new
+        auth_assertion = api.auth_assertion_header("test@paypal.com")
+        auth_assertion_array = auth_assertion.split(/[\s.]/)
+        expect(Base64.decode64(auth_assertion_array[0]).force_encoding('UTF-8')).to match alg.to_json
+        expect(Base64.decode64(auth_assertion_array[1]).force_encoding('UTF-8')).to match payload.to_json
+      end
+
+      it "generate an auth assertion header with payer id" do
+        alg = {"alg":"none"}
+        payload = {"payer_id":"TEST12345", "iss":"AYSq3RDGsmBLJE-otTkBtM-jBRd1TCQwFf9RGfwddNXWz0uFU9ztymylOhRS"}
+        api = PayPal::SDK::REST::API.new
+        auth_assertion = api.auth_assertion_header("TEST12345", true)
+        auth_assertion_array = auth_assertion.split(/[\s.]/)
+        expect(Base64.decode64(auth_assertion_array[0]).force_encoding('UTF-8')).to match alg.to_json
+        expect(Base64.decode64(auth_assertion_array[1]).force_encoding('UTF-8')).to match payload.to_json
+      end
+  end
+
+
 
 end

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -11,8 +11,8 @@ describe "Payments" do
           "funding_instruments" =>  [ {
             "credit_card" =>  {
               "type" =>  "visa",
-              "number" =>  "4567516310777851",
-              "expire_month" =>  "11", "expire_year" =>  "2018",
+              "number" =>  "4032037558005936",
+              "expire_month" =>  "12", "expire_year" =>  "2022",
               "cvv2" =>  "874",
               "first_name" =>  "Joe", "last_name" =>  "Shopper",
               "billing_address" =>  {
@@ -265,6 +265,30 @@ describe "Payments" do
         it "Refund" do
           sale   = @payment.transactions[0].related_resources[0].sale
           refund = sale.refund( :amount => { :total => "1.00", :currency => "USD" } )
+          expect(refund.error).to be_nil
+
+          refund = Refund.find(refund.id)
+          expect(refund.error).to be_nil
+          expect(refund).to be_a Refund
+        end
+      end
+    end
+
+    describe "Sale with auth assertion", :integration => true do
+
+      before :each, :disabled => true do
+        sale_id = "" #replace with payment sale id
+        @sale = Sale.find(sale_id)
+        expect(@sale.error).to be_nil
+        expect(@sale).to be_a Sale
+      end
+
+      describe "instance method" do
+        it "Refund", :disabled => true do
+          api = API.new();
+          payer_id = "" #replace with subject's payer_id
+          auth_head = api.auth_assertion_header(payer_id, true)
+          refund = @sale.refund( {:amount => { :total => "1.00", :currency => "USD" }, :auth_header => auth_head} )
           expect(refund.error).to be_nil
 
           refund = Refund.find(refund.id)


### PR DESCRIPTION
Pass auth-assertion header in the API calls if merchant doesn't have third party token