### PR TITLE
Add invoice_address methods to BillingInfo and ShippingInfo

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1835,6 +1835,24 @@ module PayPal::SDK
             object = convert_object(value, InvoiceAddress)
             instance_variable_set("@address", object)
           end
+
+          define_method "address" do |&block|
+            default_value = PayPal::SDK::Core::Util::OrderedHash.new
+            value = instance_variable_get("@address") || ( default_value && (send("address=", default_value)))
+            value = convert_object(value.to_hash, Address)
+            value
+          end
+
+          define_method "invoice_address=" do |value|
+            object = convert_object(value, InvoiceAddress)
+            instance_variable_set("@address", object)
+          end
+
+          define_method "invoice_address" do |&block|
+            default_value = PayPal::SDK::Core::Util::OrderedHash.new
+            value = instance_variable_get("@address") || ( default_value && (send("address=", default_value)))
+            value
+          end
         end
       end
 
@@ -1852,6 +1870,24 @@ module PayPal::SDK
             end
             object = convert_object(value, InvoiceAddress)
             instance_variable_set("@address", object)
+          end
+
+          define_method "address" do |&block|
+            default_value = PayPal::SDK::Core::Util::OrderedHash.new
+            value = instance_variable_get("@address") || ( default_value && (send("address=", default_value)))
+            value = convert_object(value.to_hash, Address)
+            value
+          end
+
+          define_method "invoice_address=" do |value|
+            object = convert_object(value, InvoiceAddress)
+            instance_variable_set("@address", object)
+          end
+
+          define_method "invoice_address" do |&block|
+            default_value = PayPal::SDK::Core::Util::OrderedHash.new
+            value = instance_variable_get("@address") || ( default_value && (send("address=", default_value)))
+            value
           end
         end
       end

--- a/spec/core/api/data_type_spec.rb
+++ b/spec/core/api/data_type_spec.rb
@@ -70,24 +70,90 @@ describe PayPal::SDK::Core::API::DataTypes::Base do
 
   it "billing info converts an address to invoiceaddress automatically" do
     address = Address.new(:line1 => "line1", :line2 => "line2", :status => "status" )
-    billingInfo = BillingInfo.new({
+    billing_info = BillingInfo.new({
+      :first_name => "Sally",
+      :last_name => "Patient",
+      :business_name => "Not applicable",
+    })
+    billing_info.address = address
+    expect(billing_info.address).to be_a Address
+    expect(billing_info.invoice_address).to be_a InvoiceAddress
+  end
+
+  it "shipping info returns an Address even if set to InvoiceAddress for backwards compatibility" do
+    address = InvoiceAddress.new(:line1 => "line1", :line2 => "line2", :status => "status", :phone => { :national_number => "1234567890" } )
+    billing_info = BillingInfo.new({
+      :first_name => "Sally",
+      :last_name => "Patient",
+      :business_name => "Not applicable",
+    })
+    billing_info.address = address
+    expect(billing_info.address).to be_a Address
+    expect(billing_info.invoice_address).to be_a InvoiceAddress
+    expect(billing_info.invoice_address.phone.national_number).to eql "1234567890"
+  end
+
+  it "returns the address and invoice address types in the billing info" do
+    billing_info = BillingInfo.new({
       "first_name" => "Sally",
       "last_name" => "Patient",
-      "business_name" => "Not applicable"
+      "business_name" => "Not applicable",
+      "address" => {
+        "line1" => "line1Value",
+        "phone" => { "country_code" => "123", "national_number" => "1234567890", "extension" => "456" },
+      },
     })
-    billingInfo.address = address
-    expect(billingInfo.address).to be_a InvoiceAddress
+    expect(billing_info.address).to be_a Address
+    expect(billing_info.address.line1).to eql "line1Value"
+    expect(billing_info.invoice_address).to be_a InvoiceAddress
+    expect(billing_info.invoice_address.line1).to eql "line1Value"
+    expect(billing_info.invoice_address.phone.country_code).to eql "123"
+    expect(billing_info.invoice_address.phone.national_number).to eql "1234567890"
+    expect(billing_info.invoice_address.phone.extension).to eql "456"
   end
 
   it "shipping info converts an address to invoiceaddress automatically" do
     address = Address.new(:line1 => "line1", :line2 => "line2", :status => "status" )
-    shippingInfo = ShippingInfo.new({
+    shipping_info = ShippingInfo.new({
       "first_name" => "Sally",
       "last_name" => "Patient",
-      "business_name" => "Not applicable"
+      "business_name" => "Not applicable",
     })
-    shippingInfo.address = address
-    expect(shippingInfo.address).to be_a InvoiceAddress
+    shipping_info.address = address
+    expect(shipping_info.address).to be_a Address
+    expect(shipping_info.invoice_address).to be_a InvoiceAddress
+  end
+
+  it "shipping info returns an Address even if set to InvoiceAddress for backwards compatibility" do
+    address = InvoiceAddress.new(:line1 => "line1", :line2 => "line2", :status => "status", :phone => { :national_number => "1234567890" } )
+    shipping_info = ShippingInfo.new({
+      "first_name" => "Sally",
+      "last_name" => "Patient",
+      "business_name" => "Not applicable",
+    })
+    shipping_info.address = address
+    expect(shipping_info.address).to be_a Address
+    expect(shipping_info.invoice_address).to be_a InvoiceAddress
+    expect(shipping_info.invoice_address.phone.national_number).to eql "1234567890"
+  end
+
+  it "returns the address and invoice address types in the shipping info" do
+    shipping_info = ShippingInfo.new({
+      "first_name" => "Sally",
+      "last_name" => "Patient",
+      "business_name" => "Not applicable",
+      "address" => {
+        "line1" => "line1Value",
+        "phone" => { "country_code" => "123", "national_number" => "1234567890", "extension" => "456" },
+      },
+    })
+    expect(shipping_info.address).to be_a Address
+    expect(shipping_info.address.line1).to eql "line1Value"
+    expect(shipping_info.invoice_address).to be_a InvoiceAddress
+    expect(shipping_info.invoice_address.line1).to eql "line1Value"
+    expect(shipping_info.invoice_address.phone.country_code).to eql "123"
+    expect(shipping_info.invoice_address.phone.national_number).to eql "1234567890"
+    expect(shipping_info.invoice_address.phone.extension).to eql "456"
   end
 
   it "should allow block with initializer" do


### PR DESCRIPTION
Adds additional `invoice_address` methods for accessing the new type `InvoiceAddress` and data but returning the old `Address` in the old `address` fields. This is to preserve backwards compatibility.