### PR TITLE
Remove logging of unknown fields

### DIFF
--- a/lib/paypal-sdk/core/api/data_types/base.rb
+++ b/lib/paypal-sdk/core/api/data_types/base.rb
@@ -136,7 +136,8 @@ module PayPal::SDK::Core
         def set(key, value)
           send("#{key}=", value)
         rescue NoMethodError => error
-          logger.debug error.message
+          # Uncomment to see missing fields
+          # logger.debug error.message
         rescue TypeError, ArgumentError => error
           raise TypeError, "#{error.message}(#{value.inspect}) for #{self.class.name}.#{key} member"
         end


### PR DESCRIPTION
When new fields are introduced into responses and the currently installed SDK version does not support the fields, there is some debug logging like:

```
 undefined method `currency_code=' for #<PayPal::SDK::REST::DataTypes::Plan:0x007faac95092d8>
undefined method `recipient_name=' for #<PayPal::SDK::REST::DataTypes::Address:0x007faac94eb5d0>
```

This logging seems to have caused confusion. The proposed solution is to remove the logging.