### PR TITLE
require 'net/http' in data_types.rb

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 require 'multi_json'
 require 'zlib'
 require "base64"
+require 'net/http'
 
 module PayPal::SDK
   module REST


### PR DESCRIPTION
`data_types.rb` references `Net::HTTP`, but it is not required in that file which causes `NameError (uninitialized constant Net)` exception on webhook validation.