### PR TITLE
Add application_context to Payment

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -75,6 +75,7 @@ module PayPal::SDK
           object_of :potential_payer_info, PotentialPayerInfo
           object_of :credit_financing_offered, CreditFinancingOffered
           object_of :failure_reason, String
+          object_of :application_context, ApplicationContext
         end
 
         include RequestDataType
@@ -2493,6 +2494,16 @@ module PayPal::SDK
           object_of :input_fields, InputFields
           object_of :presentation, Presentation
           object_of :temporary, Boolean
+        end
+      end
+
+      class ApplicationContext < Base
+        def self.load_members
+          object_of :brand_name, String
+          object_of :locale, String
+          object_of :landing_page, String
+          object_of :shipping_preference, String
+          object_of :user_action, String
         end
       end
 


### PR DESCRIPTION
[Documentation](https://developer.paypal.com/docs/api/payments/#payment_create) suggests that `application_context` can be sent as parameters during creation of a payment.

This pull request simply allows those parameters to pass through into the request.