### PR TITLE
Add a warning about the Webhook Simulator

### DIFF
--- a/samples/notifications/verify_webhook_event.rb
+++ b/samples/notifications/verify_webhook_event.rb
@@ -32,6 +32,7 @@ event_body = '{"id":"WH-0G2756385H040842W-5Y612302CV158622M","create_time":"2015
 
 # verify webhook
 # pass all the field to `WebhookEvent.verify()` method which returns true or false based on validation
+# make sure you are not using Webhooks simulator because mocks can't be validated: https://developer.paypal.com/developer/webhooksSimulator/
 valid = WebhookEvent.verify(transmission_id, timestamp, webhook_id, event_body, cert_url, actual_signature, auth_algo)
 
 if valid


### PR DESCRIPTION
I believe that many developers have lost many hours due to trying validate webhook using the simulator and always getting false from `WebhookEvent.verify`.
Let's end this already.