### PR TITLE
add 'amount' to PaymentDetail

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -2004,6 +2004,7 @@ module PayPal::SDK
           object_of :date, String
           object_of :method, String
           object_of :note, String
+          object_of :amount, Currency
         end
       end
 


### PR DESCRIPTION
The api supports it:
https://developer.paypal.com/docs/api/invoicing/v1/#definition-payment_detail

and it is a pretty essential detail of a payment.. you know, the actual amount of the payment 😉 