### PR TITLE
Make Order#authorize accept authorization amount

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -942,9 +942,14 @@ module PayPal::SDK
           success?
         end
 
-        def authorize()
+        def authorize(authorization = nil)
+          authorization_body = if authorization.nil?
+                                 self
+                               else
+                                 authorization.is_a?(Authorization) ? authorization : Authorization.new(authorization)
+                               end
           path = "v1/payments/orders/#{self.id}/authorize"
-          response = api.post(path, self.to_hash, http_header)
+          response = api.post(path, authorization_body.to_hash, http_header)
           Authorization.new(response)
         end
 

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -297,6 +297,16 @@ describe "Payments" do
         expect(auth.state).to eq("Pending")
       end
 
+      it "Authorize (with amount)", :disabled => true do
+        auth = order.authorize({
+          "amount" => {
+            "currency" => "USD",
+            "total" => "1.00"
+          }
+        })
+        expect(auth.state).to eq("Pending")
+      end
+
       it "Capture", :disabled => true do
         capture = Capture.new({
             "amount" => {


### PR DESCRIPTION
The `Order#authorize` method does not currently behave correctly in accordance with the [API docs](https://developer.paypal.com/docs/api/payments/v1/#orders_authorize), since it accepts no parameters and instead will (I believe) always attempt to create an authorization for the full order value. This specifically will not work for the use-case where one needs to perform multiple authorizations and captures against a single Order.

This PR updates the method to (optionally) accept an authorization hash - specifically, we want to pass in an `amount` hash as outlined in the docs above, but the pattern in this repo seems to be to pass in complete PayPal data-type instances whenever possible (as in the `capture` method above this one).

The closest thing I could find to an existing sample or spec for this functionality was in `payments_examples_spec`, so I've updated that with an example usage of this change.