### PR TITLE
Conform to logger parameters

### DIFF
--- a/lib/paypal-sdk/core/util/http_helper.rb
+++ b/lib/paypal-sdk/core/util/http_helper.rb
@@ -92,6 +92,7 @@ module PayPal::SDK::Core
 
         logger.add(
           response_details_log_level(response),
+          nil,
           "Response.body=#{response.body}\tResponse.header=#{response.to_hash}"
         )
 


### PR DESCRIPTION
To better conform to Ruby logger implementation, I added a `nil` to the parameters. 

This issue happens when I'm using 3rd party logger middleware, it raises error `ArgumentError: wrong number of arguments (given 2, expected 3..4)` https://github.com/discourse/logster/blob/master/lib/logster/logger.rb#L60. So I think we'd better follow Ruby logger implementation.

``` ruby
def info(progname = nil, &block)
  add(INFO, nil, progname, &block)
end
```