### PR TITLE
Pass block to logger so the entire block will not be evaluated if the…

### DIFF
--- a/lib/paypal-sdk/core/api/rest.rb
+++ b/lib/paypal-sdk/core/api/rest.rb
@@ -167,7 +167,7 @@ module PayPal::SDK::Core
       # Log PayPal-Request-Id header
       def log_http_call(payload)
         if payload[:header] and payload[:header]["PayPal-Request-Id"]
-          logger.info "PayPal-Request-Id: #{payload[:header]["PayPal-Request-Id"]}"
+          logger.info {"PayPal-Request-Id: #{payload[:header]["PayPal-Request-Id"]}"}
         end
         super
       end

--- a/lib/paypal-sdk/core/logging.rb
+++ b/lib/paypal-sdk/core/logging.rb
@@ -20,7 +20,7 @@ module PayPal::SDK::Core
       start_time = Time.now
       block.call
     ensure
-      logger.info sprintf("[%.3fs] %s", Time.now - start_time, message)
+      logger.info {sprintf("[%.3fs] %s", Time.now - start_time, message)}
     end
 
     class << self

--- a/lib/paypal-sdk/core/util/http_helper.rb
+++ b/lib/paypal-sdk/core/util/http_helper.rb
@@ -81,19 +81,17 @@ module PayPal::SDK::Core
       # Log Http call
       # * payload - Hash(:http, :method, :uri, :body, :header)
       def log_http_call(payload)
-        logger.info "Request[#{payload[:method]}]: #{payload[:uri].to_s}"
+        logger.info {"Request[#{payload[:method]}]: #{payload[:uri].to_s}"}
 
-        logger.debug "Request.body=#{payload[:body]}\trequest.header=#{payload[:header]}"
+        logger.debug {"Request.body=#{payload[:body]}\trequest.header=#{payload[:header]}"}
 
         start_time = Time.now
         response = yield
-        logger.info sprintf("Response[%s]: %s, Duration: %.3fs", response.code,
-          response.message, Time.now - start_time)
+        logger.info {
+          sprintf("Response[%s]: %s, Duration: %.3fs", response.code, response.message, Time.now - start_time)
+        }
 
-        logger.add(
-          response_details_log_level(response),
-          "Response.body=#{response.body}\tResponse.header=#{response.to_hash}"
-        )
+        logger.add(response_details_log_level(response)) {"Response.body=#{response.body}\tResponse.header=#{response.to_hash}"}
 
         response
       end


### PR DESCRIPTION
There will be a slight performance impact if the string passed to logger includes instantiating the somewhat heavy String object even if the allowed output level doesn't include debug. 

The reason is that Ruby has to evaluate these strings, which interpolating the variables. Therefore, it's recommended to pass blocks to the logger methods, as these are only evaluated if the output level is the same as — or included in — the allowed level (i.e. lazy loading)