### PR TITLE
Removes unused dependency

### DIFF
--- a/paypal-sdk-rest.gemspec
+++ b/paypal-sdk-rest.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{The PayPal REST SDK provides Ruby APIs to create, process and manage payment.}
   gem.description   = %q{The PayPal REST SDK provides Ruby APIs to create, process and manage payment.}
   gem.homepage      = "https://developer.paypal.com"
-  
+
   gem.license       = "PayPal SDK License"
 
   gem.files         = Dir["{bin,spec,lib}/**/*"] + ["Rakefile", "README.md", "Gemfile"] + Dir["data/*"]
@@ -20,6 +20,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency('coveralls')
-  gem.add_dependency('xml-simple')
   gem.add_dependency('multi_json', '~> 1.0')
 end


### PR DESCRIPTION
[xml-simple](https://github.com/maik/xml-simple) was listed as a dependency
in the `gemspec`, but it wasn't used by any code.

This removes the dependency.

Tests all pass locally.