### PR TITLE
Update supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 dist: trusty
 language: ruby
 rvm:
-  - "2.0.0"
-  - "2.2.5"
+  - "2.6"
   - "2.3.1"
 script: "bundle exec rspec"
 

--- a/paypal-sdk-rest.gemspec
+++ b/paypal-sdk-rest.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |gem|
   
   gem.license       = "PayPal SDK License"
 
+  gem.required_ruby_version = '>= 2.3'
+
   gem.files         = Dir["{bin,spec,lib}/**/*"] + ["Rakefile", "README.md", "Gemfile"] + Dir["data/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
I am experiencing a bundle failure with Ruby 2.2, eg. https://travis-ci.org/varyonic/PayPal-Ruby-SDK/jobs/547356099

Dependency public_suffix release 3.1 dropped obsolete Ruby 2.2 support:

```
Gem::RuntimeRequirementNotMetError: public_suffix requires Ruby version >= 2.3.
The current ruby version is 2.2.0.
An error occurred while installing public_suffix (3.1.0), and
Bundler cannot continue.
Make sure that `gem install public_suffix -v '3.1.0' --source
'https://rubygems.org/'` succeeds before bundling.
In Gemfile:
  releasinator was resolved to 0.7.6, which depends on
    octokit was resolved to 4.14.0, which depends on
      sawyer was resolved to 0.8.2, which depends on
        addressable was resolved to 2.6.0, which depends on
          public_suffix
```
This is probably related to: https://github.com/weppos/publicsuffix-ruby/issues/161
