### PR TITLE
Paypal has removed the old sandbox endpoint in favor of this new one

### DIFF
--- a/lib/paypal-sdk/core/api/ipn.rb
+++ b/lib/paypal-sdk/core/api/ipn.rb
@@ -5,7 +5,7 @@ module PayPal
         module IPN
 
           END_POINTS = {
-            :sandbox => "https://www.sandbox.paypal.com/cgi-bin/webscr",
+            :sandbox => "https://ipnpb.sandbox.paypal.com/cgi-bin/webscr",
             :live    => "https://ipnpb.paypal.com/cgi-bin/webscr"
           }
           VERIFIED   = "VERIFIED"


### PR DESCRIPTION
Had an outage this week on our staging environment, updating the url fixes the issue.