### PR TITLE
Created Subscription DataType to replace deprecated Billing Agreement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ test/version_tmp
 tmp
 .idea
 Gemfile.lock
+.ruby-version
+.rbenv-gemsets

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'simplecov', :require => false
   gem 'rspec'
   gem 'webmock'
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 gem 'releasinator', '~> 0.6'

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -176,6 +176,98 @@ module PayPal::SDK
         include RequestDataType
       end
 
+      class SubscriptionPlan < Base
+        def self.load_members
+          object_of :id, String
+          object_of :product_id, String
+          object_of :name, String
+          object_of :description, String
+          object_of :status, String
+          array_of :billing_cycles CycleExecution
+          object_of :taxes, Tax
+          object_of :create_time, String
+          object_of :update_time, String
+          array_of  :links, Links
+        end
+
+        include RequestDataType
+
+        def create()
+          path = "v1/billing/plans"
+          response = api.post(path, self.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def update(patch_requests)
+          patch_request_array = []
+          patch_requests.each do |patch_request|
+            patch_request = Patch.new(patch_request) unless patch_request.is_a? Patch
+            patch_request_array << patch_request.to_hash
+          end
+          path = "v1/billing/plans/#{self.id}"
+          response = api.patch(path, patch_request_array, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def activate()
+          path = "v1/billing/plans/#{self.id}/activate"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def deactivate()
+          path = "v1/billing/plans/#{self.id}/deactivate"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def update_pricing(pricing_schemes)
+          path = "v1/billing/plans/#{self.id}/deactivate"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        class << self
+          def find(resource_id)
+            raise ArgumentError.new("id required") if resource_id.to_s.strip.empty?
+            path = "v1/billing/plans/#{resource_id}"
+            self.new(api.get(path))
+          end
+
+          def all()
+            path = "v1/billing/plans"
+            SubscriptionPlanList.new(api.get(path, options))
+          end
+        end
+      end
+
+      class SubscriptionPlanList < Base
+        def self.load_members
+          array_of  :plans, SubscriptionPlan
+          object_of :total_items, String
+          object_of :total_pages, String
+          array_of  :links, Links
+        end
+      end
+
+      class PricingSchemeList < Base
+        def self.load_members
+          array_of :pricing_schemes, PricingScheme
+        end
+      end
+
+      class PricingScheme < Base
+        def self.load_members
+          object_of :billing_cycle_sequence, Integer
+          object_of :pricing_scheme, Currency
+        end
+      end
+
       class Subscription < Base
         def self.load_members
           object_of :id, String
@@ -262,11 +354,6 @@ module PayPal::SDK
             path = "v1/billing/subscriptions/#{resource_id}"
             self.new(api.get(path))
           end
-
-          def all(options = {})
-            path = "v1/billing/subscriptions"
-            PaymentHistory.new(api.get(path, options))
-          end
         end
       end
 
@@ -279,68 +366,98 @@ module PayPal::SDK
       end
 
       class ShippingAddress < Base
-        object_of :name, ShippingAddressName
-        object_of :address, Address
+        def self.load_members
+          object_of :name, ShippingAddressName
+          object_of :address, Address
+        end
       end
 
       class SubscriberName < Base
-        object_of :given_name, String
-        object_of :surname, String
+        def self.load_members
+          object_of :given_name, String
+          object_of :surname, String
+        end
       end
 
       class ShippingAddressName < Base
-        object_of :name, Name
+        def self.load_members
+          object_of :name, String
+        end
       end
 
       class Name < Base
-        object_of :full_name, String
+        def self.load_members
+          object_of :full_name, String
+        end
       end
 
       class SubscriptionBillingInfo < Base
-        object_of :outstanding_balance, Currency
-        array_of  :cycle_executions, CycleExecution
-        object_of :last_payment, LastPayment
-        object_of :next_billing_time, String
-        object_of :failed_payments_count, String
+        def self.load_members
+          object_of :outstanding_balance, Currency
+          array_of  :cycle_executions, CycleExecution
+          object_of :last_payment, LastPayment
+          object_of :next_billing_time, String
+          object_of :failed_payments_count, String
+        end
       end
 
       class CycleExecution < Base
-        object_of :tenure_type, String
-        object_of :sequence, String
-        object_of :cycles_completed, String
-        object_of :cycles_remaining, String
-        object_of :total_cycles, String
+        def self.load_members
+          object_of :tenure_type, String
+          object_of :sequence, String
+          object_of :cycles_completed, String
+          object_of :cycles_remaining, String
+          object_of :total_cycles, String
+          object_of :frequency, Frequency
+        end
+      end
+
+      class Frequency < Base
+        def self.load_members
+          object_of :interval_unit, String
+          object_of :interval_count, Integer
+        end
       end
 
       class LastPayment < Base
-        object_of :amount, Currency
-        object_of :time, String
+        def self.load_members
+          object_of :amount, Currency
+          object_of :time, String
+        end
       end
 
       class SubscriptionCapture < Base
-        object_of :note, String
-        object_of :capture_type, String
-        object_of :amount, Currency
+        def self.load_members
+          object_of :note, String
+          object_of :capture_type, String
+          object_of :amount, Currency
+        end
       end
 
       class Reason < Base
-        object_of :reason, String
+        def self.load_members
+          object_of :reason, String
+        end
       end
 
       class Revision < Base
-        object_of :plan_id, String
-        object_of :shipping_amount, Currency
-        object_of :shipping_address, ShippingAddress
-        object_of :application_context, ApplicationContext
+        def self.load_members
+          object_of :plan_id, String
+          object_of :shipping_amount, Currency
+          object_of :shipping_address, ShippingAddress
+          object_of :application_context, ApplicationContext
+        end
       end
 
       class ApplicationContext < Base
-        object_of :brand_name, String
-        object_of :locale, String
-        object_of :shipping_preference, String
-        object_of :payment_method, PaymentMethod
-        object_of :return_url, String
-        object_of :cancel_url, String
+        def self.load_members
+          object_of :brand_name, String
+          object_of :locale, String
+          object_of :shipping_preference, String
+          object_of :payment_method, PaymentMethod
+          object_of :return_url, String
+          object_of :cancel_url, String
+        end
       end
 
       class PaymentMethod < Base
@@ -2161,6 +2278,7 @@ module PayPal::SDK
           object_of :name, String
           object_of :percent, Number
           object_of :amount, Currency
+          object_of :inclusive, String
         end
       end
 

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -176,6 +176,46 @@ module PayPal::SDK
         include RequestDataType
       end
 
+      class Product < Base
+        def self.load_members
+          object_of :name, String
+          object_of :description, String
+          object_of :type, String
+          object_of :category, String
+          object_of :image_url, String
+          object_of :home_url, String
+        end
+
+        include RequestDataType
+
+        def create()
+          path = "v1/catalogs/products"
+          response = api.post(path, self.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        class << self
+          def find(resource_id)
+            raise ArgumentError.new("id required") if resource_id.to_s.strip.empty?
+            path = "v1/catalogs/products/#{resource_id}"
+            self.new(api.get(path))
+          end
+
+          def all()
+            path = "v1/catalogs/products"
+            ProductList.new(api.get(path, options))
+          end
+        end
+      end
+
+      def ProductList < Base
+        def self.load_members
+          array_of :products, Product
+          array_of :links, Links
+        end
+      end
+
       class SubscriptionPlan < Base
         def self.load_members
           object_of :id, String

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -396,7 +396,7 @@ module PayPal::SDK
         def transactions(start_time, end_time)
           path = "v1/billing/subscriptions/#{self.id}/transactions"
           options = { :start_time => start_time, :end_time => end_time }
-          self.new(api.get(path, options))
+          SubscriptionTransactionList.new(api.get(path, options))
         end
 
         raise_on_api_error :create, :update, :activate, :cancel, :capture, :revise, :suspend, :transactions
@@ -500,6 +500,32 @@ module PayPal::SDK
           object_of :shipping_amount, Currency
           object_of :shipping_address, ShippingAddress
           object_of :application_context, ApplicationContext
+        end
+      end
+
+      class SubscriptionTransactionList < Base
+        def self.load_members
+          array_of :transactions, SubscriptionTransaction
+          array_of :links, Links
+        end
+      end
+
+      class SubscriptionTransaction < Base
+        def self.load_members
+          object_of :id, String
+          object_of :status, String
+          object_of :payer_email, String
+          object_of :payer_name, SubscriberName
+          object_of :amount_with_breakdown, AmountWithBreakdown
+          object_of :time, String
+        end
+      end
+
+      class AmountWithBreakdown < Base
+        def self.load_members
+          object_of :gross_amount, Currency
+          object_of :fee_amount, Currency
+          object_of :net_amount, Currency
         end
       end
 

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -176,6 +176,178 @@ module PayPal::SDK
         include RequestDataType
       end
 
+      class Subscription < Base
+        def self.load_members
+          object_of :id, String
+          object_of :plan_id, String
+          object_of :start_time, String
+          object_of :quantity, String
+          object_of :shipping_amount, Currency
+          object_of :subscriber, Subscriber
+          object_of :billing_info, BillingInfo
+          object_of :create_time, String
+          object_of :update_time, String
+          array_of  :links, Links
+          object_of :status, String
+          object_of :status_update_time, String
+        end
+
+        include RequestDataType
+
+        def create()
+          path = "v1/billing/subscriptions"
+          response = api.post(path, self.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def update(patch_requests)
+          patch_request_array = []
+          patch_requests.each do |patch_request|
+            patch_request = Patch.new(patch_request) unless patch_request.is_a? Patch
+            patch_request_array << patch_request.to_hash
+          end
+          path = "v1/billing/subscriptions/#{self.id}"
+          response = api.patch(path, patch_request_array, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def activate(reason)
+          path = "v1/billing/subscriptions/#{self.id}/activate"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def cancel(reason)
+          path = "v1/billing/subscriptions/#{self.id}/cancel"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def capture(subscription_capture)
+          path = "v1/billing/subscriptions/#{self.id}/capture"
+          response = api.post(path, capture.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def revise(revision)
+          path = "v1/billing/subscriptions/#{self.id}/revise"
+          response = api.post(path, revision.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def suspend(reason)
+          path = "v1/billing/subscriptions/#{self.id}/suspend"
+          response = api.post(path, reason.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+
+        def transactions(start_time, end_time)
+          path = "v1/billing/subscriptions/#{self.id}/transactions"
+          options = { :start_time => start_time, :end_time => end_time }
+          self.new(api.get(path, options))
+        end
+
+        raise_on_api_error :create, :update, :activate, :cancel, :capture, :revise, :suspend, :transactions
+
+        class << self
+          def find(resource_id)
+            raise ArgumentError.new("id required") if resource_id.to_s.strip.empty?
+            path = "v1/billing/subscriptions/#{resource_id}"
+            self.new(api.get(path))
+          end
+
+          def all(options = {})
+            path = "v1/billing/subscriptions"
+            PaymentHistory.new(api.get(path, options))
+          end
+        end
+      end
+
+      class Subscriber < Base
+        def self.load_members
+          object_of :shipping_address, ShippingAddress
+          object_of :name, SubscriberName
+          object_of :email_address, String
+        end
+      end
+
+      class ShippingAddress < Base
+        object_of :name, ShippingAddressName
+        object_of :address, Address
+      end
+
+      class SubscriberName < Base
+        object_of :given_name, String
+        object_of :surname, String
+      end
+
+      class ShippingAddressName < Base
+        object_of :name, Name
+      end
+
+      class Name < Base
+        object_of :full_name, String
+      end
+
+      class SubscriptionBillingInfo < Base
+        object_of :outstanding_balance, Currency
+        array_of  :cycle_executions, CycleExecution
+        object_of :last_payment, LastPayment
+        object_of :next_billing_time, String
+        object_of :failed_payments_count, String
+      end
+
+      class CycleExecution < Base
+        object_of :tenure_type, String
+        object_of :sequence, String
+        object_of :cycles_completed, String
+        object_of :cycles_remaining, String
+        object_of :total_cycles, String
+      end
+
+      class LastPayment < Base
+        object_of :amount, Currency
+        object_of :time, String
+      end
+
+      class SubscriptionCapture < Base
+        object_of :note, String
+        object_of :capture_type, String
+        object_of :amount, Currency
+      end
+
+      class Reason < Base
+        object_of :reason, String
+      end
+
+      class Revision < Base
+        object_of :plan_id, String
+        object_of :shipping_amount, Currency
+        object_of :shipping_address, ShippingAddress
+        object_of :application_context, ApplicationContext
+      end
+
+      class ApplicationContext < Base
+        object_of :brand_name, String
+        object_of :locale, String
+        object_of :shipping_preference, String
+        object_of :payment_method, PaymentMethod
+        object_of :return_url, String
+        object_of :cancel_url, String
+      end
+
+      class PaymentMethod < Base
+        object_of :payer_selected, String
+        object_of :payee_preferred, String
+      end
+
       class BillingAgreementToken < Base
         def self.load_members
         end
@@ -369,6 +541,8 @@ module PayPal::SDK
         def self.load_members
           object_of :line1, String
           object_of :line2, String
+          object_of :admin_area_1, String
+          object_of :admin_area_2, String
           object_of :city, String
           object_of :country_code, String
           object_of :postal_code, String
@@ -963,7 +1137,8 @@ module PayPal::SDK
           object_of :transaction_fee, Currency
           object_of :create_time, String
           object_of :update_time, String
-          array_of  :links, Links
+          array_of  :links, Links,
+          object_of :capture_type, String
         end
 
         include RequestDataType

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -203,7 +203,7 @@ module PayPal::SDK
             self.new(api.get(path))
           end
 
-          def all()
+          def all(options = {})
             path = "v1/catalogs/products"
             ProductList.new(api.get(path, options))
           end
@@ -219,8 +219,8 @@ module PayPal::SDK
 
       class PaymentPreference < Base
         def self.load_members
-          object_of :auto_bill_outstanding, Boolean
           object_of :setup_fee, Currency
+          object_of :auto_bill_outstanding, Boolean
           object_of :setup_fee_failure_action, String
           object_of :payment_failure_threshold, Integer
         end
@@ -237,6 +237,7 @@ module PayPal::SDK
           object_of :payment_preferences, PaymentPreference
           object_of :taxes, Tax
           object_of :quantity_supported, Boolean
+          object_of :reason, String
           object_of :create_time, String
           object_of :update_time, String
           array_of  :links, Links
@@ -251,35 +252,32 @@ module PayPal::SDK
           success?
         end
 
-        def update(patch_requests)
-          patch_request_array = []
-          patch_requests.each do |patch_request|
-            patch_request = Patch.new(patch_request) unless patch_request.is_a? Patch
-            patch_request_array << patch_request.to_hash
-          end
+        def update(patch)
+          patch = Patch.new(patch) unless patch.is_a? Patch
+          patch_request = Array.new(1, patch.to_hash)
           path = "v1/billing/plans/#{self.id}"
-          response = api.patch(path, patch_request_array, http_header)
+          response = api.patch(path, patch_request, http_header)
           self.merge!(response)
           success?
         end
 
         def activate()
           path = "v1/billing/plans/#{self.id}/activate"
-          response = api.post(path, reason.to_hash, http_header)
+          response = api.post(path, self.to_hash, http_header)
           self.merge!(response)
           success?
         end
 
         def deactivate()
           path = "v1/billing/plans/#{self.id}/deactivate"
-          response = api.post(path, reason.to_hash, http_header)
+          response = api.post(path, self.to_hash, http_header)
           self.merge!(response)
           success?
         end
 
         def update_pricing(pricing_schemes)
-          path = "v1/billing/plans/#{self.id}/deactivate"
-          response = api.post(path, reason.to_hash, http_header)
+          path = "v1/billing/plans/#{self.id}/update-pricing-schemes"
+          response = api.post(path, pricing_schemes.to_hash, http_header)
           self.merge!(response)
           success?
         end
@@ -291,7 +289,7 @@ module PayPal::SDK
             self.new(api.get(path))
           end
 
-          def all()
+          def all(options = {})
             path = "v1/billing/plans"
             SubscriptionPlanList.new(api.get(path, options))
           end
@@ -315,8 +313,9 @@ module PayPal::SDK
 
       class PricingScheme < Base
         def self.load_members
+          object_of :version, Integer
           object_of :billing_cycle_sequence, Integer
-          object_of :pricing_scheme, Currency
+          object_of :fixed_price, Currency
         end
       end
 
@@ -463,6 +462,7 @@ module PayPal::SDK
           object_of :cycles_remaining, String
           object_of :total_cycles, String
           object_of :frequency, Frequency
+          object_of :pricing_scheme, PricingScheme
         end
       end
 
@@ -875,6 +875,7 @@ module PayPal::SDK
       class Currency < Base
         def self.load_members
           object_of :currency, String
+          object_of :currency_code, String
           object_of :value, String
         end
       end
@@ -2331,6 +2332,7 @@ module PayPal::SDK
           object_of :id, String
           object_of :name, String
           object_of :percent, Number
+          object_of :percentage, Number
           object_of :amount, Currency
           object_of :inclusive, String
         end

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -178,6 +178,7 @@ module PayPal::SDK
 
       class Product < Base
         def self.load_members
+          object_of :id, String
           object_of :name, String
           object_of :description, String
           object_of :type, String
@@ -209,10 +210,19 @@ module PayPal::SDK
         end
       end
 
-      def ProductList < Base
+      class ProductList < Base
         def self.load_members
           array_of :products, Product
           array_of :links, Links
+        end
+      end
+
+      class PaymentPreference < Base
+        def self.load_members
+          object_of :auto_bill_outstanding, Boolean
+          object_of :setup_fee, Currency
+          object_of :setup_fee_failure_action, String
+          object_of :payment_failure_threshold, Integer
         end
       end
 
@@ -223,8 +233,10 @@ module PayPal::SDK
           object_of :name, String
           object_of :description, String
           object_of :status, String
-          array_of :billing_cycles CycleExecution
+          array_of :billing_cycles, CycleExecution
+          object_of :payment_preferences, PaymentPreference
           object_of :taxes, Tax
+          object_of :quantity_supported, Boolean
           object_of :create_time, String
           object_of :update_time, String
           array_of  :links, Links
@@ -317,6 +329,8 @@ module PayPal::SDK
           object_of :shipping_amount, Currency
           object_of :subscriber, Subscriber
           object_of :billing_info, BillingInfo
+          object_of :status_change_note, String
+          object_of :status_update_time, String
           object_of :create_time, String
           object_of :update_time, String
           array_of  :links, Links

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1137,7 +1137,7 @@ module PayPal::SDK
           object_of :transaction_fee, Currency
           object_of :create_time, String
           object_of :update_time, String
-          array_of  :links, Links,
+          array_of  :links, Links
           object_of :capture_type, String
         end
 

--- a/spec/subscription_2_examples_spec.rb
+++ b/spec/subscription_2_examples_spec.rb
@@ -13,7 +13,7 @@ describe "Subscription" do
 
 	SubscriptionPlanAttributes = {
 	  "name": "Monthy Subscription to the Collegian",
-      "status": "CREATED",
+      "status": "ACTIVE",
       "description": "1 print copy of The Collegian delivered to your address.",
       "billing_cycles": [
         {
@@ -122,7 +122,7 @@ describe "Subscription" do
 	}
 
 	describe "Product", :integration => true do
-		xit "Create" do
+		it "Create" do
 	      $api = API.new
 	      $product = Product.new(ProductAttributes.merge( :token => $api.token ))
 	      expect(Product.api).not_to eql $product.api
@@ -134,7 +134,7 @@ describe "Subscription" do
 	      expect($product.id).not_to be_nil
 	    end
 
-	    xit "Find" do
+	    it "Find" do
 	      api = API.new
 	      product = Product.find($product.id)
 	      expect(product.id).to eq($product.id)
@@ -142,7 +142,7 @@ describe "Subscription" do
 	      expect(product.type).to eq("PHYSICAL")
 	    end
 
-	    xit "List" do
+	    it "List" do
 	    	product_list = Product.all()
       		expect(product_list.error).to be_nil
       		expect(product_list.products.count).to be > 0
@@ -150,7 +150,7 @@ describe "Subscription" do
 	end
 
 	describe "Plan", :integration => true do
-		xit "Create" do
+		it "Create" do
 			$api = API.new
 	    	$plan = SubscriptionPlan.new(SubscriptionPlanAttributes.merge( :token => $api.token ))
 	    	$plan.product_id = $product.id	    	
@@ -163,7 +163,7 @@ describe "Subscription" do
 	    	expect($plan.id).not_to be_nil
 		end
 
-		xit "Update" do
+		it "Update" do
 			# set up a patch request
 			patch = Patch.new
 			patch.op = "replace"
@@ -173,29 +173,29 @@ describe "Subscription" do
 			expect($plan.update( patch )).to be_truthy
 		end
 
-		xit "Activate" do
-	      expect( $plan.activate ).to be_truthy
+		it "Deactivate" do
+			expect( $plan.deactivate ).to be_truthy
 		end
 
-		xit "Deactivate" do
-			expect( $plan.deactivate ).to be_truthy
+		it "Activate" do
+	      expect( $plan.activate ).to be_truthy
 		end
 		
 		it "Update Pricing" do
-			$plan = SubscriptionPlan.find('P-80959566P4933662RLXNWE3Y')
+			$plan = SubscriptionPlan.find($plan_id)
 			pricing_schemes = PricingSchemeList.new()
 			pricing_schemes.pricing_schemes << PricingSchemeAttributes #{ :billing_cycle_sequence => 3, :pricing_scheme  => {:fixed_price => {:value => "30", :currency_code => 'USD'}}}
 			$plan.update_pricing(pricing_schemes)
 			expect( $plan.update_pricing(pricing_schemes) ).to be_truthy
 		end
 
-		xit "Find" do
+		it "Find" do
 			plan = SubscriptionPlan.find($plan.id)
 			expect(plan.id).to eq($plan.id)
 		    expect(plan.name).to eq("Monthy Subscription to the Collegian")
 		end
 
-		xit "List" do
+		it "List" do
 			plan_list = SubscriptionPlan.all()
       		expect(plan_list.error).to be_nil
       		expect(plan_list.plans.count).to be > 0
@@ -203,10 +203,10 @@ describe "Subscription" do
 	end
 
 	describe "Subscription", :integration => true do
-		xit "Create" do
+		it "Create" do
 			$api = API.new
 			$subscription = Subscription.new(SubscriptionAttributes.merge( :token => $api.token ))
-			$subscription.plan_id = "P-80959566P4933662RLXNWE3Y" #$plan.id
+			$subscription.plan_id = $plan.id #"P-80959566P4933662RLXNWE3Y"
 			$subscription.create
 
 		    expect($subscription.error).to be_nil
@@ -214,13 +214,14 @@ describe "Subscription" do
 		end
 
 		it "Find" do
-			subscription_id = 'I-1L0VUJJ9X8K5'
+			subscription_id = $subscription.id #'I-1L0VUJJ9X8K5'
 			$subscription = Subscription.find(subscription_id)
 			expect(subscription_id).to eq($subscription.id)
-		    expect('P-80959566P4933662RLXNWE3Y').to eq($subscription.plan_id)
+		    expect($plan.id).to eq($subscription.plan_id)
 		end
 
-		xit "Update" do
+		it "Update" do
+			$subscription = Subscription.find('I-0B7813AYW19B') #subscription created earlier needs to be approved by the user
 			patch = Patch.new
 			patch.op = "replace"
 			patch.path = "/shipping_amount"
@@ -245,24 +246,24 @@ describe "Subscription" do
 			expect($subscription.capture(subscription_capture)).to be_truthy
 		end
 
-		xit "Revise" do
+		it "Revise" do
 			revision = {
 				"quantity": 2
 			}
 			expect($subscription.revise(revision)).to be_truthy
 		end
 
-		xit "Suspend" do 
+		it "Suspend" do 
 			reason = {"reason":"Closed for Winter break"}
 			expect($subscription.suspend(reason)).to be_truthy
 		end
 
-		xit "Activate" do
+		it "Activate" do
 			reason = {"reason":"Open for Spring"}
 			expect($subscription.activate(reason)).to be_truthy
 		end
 
-		xit "Cancel" do
+		it "Cancel" do
 			reason = {"reason":"Closing circulation"}
 			expect($subscription.cancel(reason)).to be_truthy
 		end

--- a/spec/subscription_2_examples_spec.rb
+++ b/spec/subscription_2_examples_spec.rb
@@ -3,122 +3,122 @@ require 'time'
 
 describe "Subscription" do
 	ProductAttributes = {
-		"name": "The Collegian",
-		"description": "Official newsletter of CPM University",
-		"type": "PHYSICAL",
-		"category": "BOOKS_PERIODICALS_AND_NEWSPAPERS",
-		"image_url": "https://example.com",
-		"home_url": "https://example.com"
+		"name"=> "The Collegian",
+		"description"=> "Official newsletter of CPM University",
+		"type"=> "PHYSICAL",
+		"category"=> "BOOKS_PERIODICALS_AND_NEWSPAPERS",
+		"image_url"=> "https://example.com",
+		"home_url"=> "https://example.com"
 	}
 
 	SubscriptionPlanAttributes = {
-	  "name": "Monthy Subscription to the Collegian",
-      "status": "ACTIVE",
-      "description": "1 print copy of The Collegian delivered to your address.",
-      "billing_cycles": [
+	  "name"=> "Monthy Subscription to the Collegian",
+      "status"=> "ACTIVE",
+      "description"=> "1 print copy of The Collegian delivered to your address.",
+      "billing_cycles"=> [
         {
-          "frequency": {
-            "interval_unit": "MONTH",
-            "interval_count": 1
+          "frequency"=> {
+            "interval_unit"=> "MONTH",
+            "interval_count"=> 1
           },
-          "tenure_type": "TRIAL",
-          "sequence": 1,
-          "total_cycles": 1,
-          "pricing_scheme": {
-            "fixed_price": {
-              "value": "0",
-              "currency_code": "USD"
+          "tenure_type"=> "TRIAL",
+          "sequence"=> 1,
+          "total_cycles"=> 1,
+          "pricing_scheme"=> {
+            "fixed_price"=> {
+              "value"=> "0",
+              "currency_code"=> "USD"
             }
           }
         },
         {
-          "frequency": {
-            "interval_unit": "MONTH",
-            "interval_count": 1
+          "frequency"=> {
+            "interval_unit"=> "MONTH",
+            "interval_count"=> 1
           },
-          "tenure_type": "REGULAR",
-          "sequence": 2,
-          "total_cycles": 12,
-          "pricing_scheme": {
-            "fixed_price": {
-              "value": "29.99",
-              "currency_code": "USD"
+          "tenure_type"=> "REGULAR",
+          "sequence"=> 2,
+          "total_cycles"=> 12,
+          "pricing_scheme"=> {
+            "fixed_price"=> {
+              "value"=> "29.99",
+              "currency_code"=> "USD"
             }
           }
         }
       ],
-      "payment_preferences": {
-        "auto_bill_outstanding": true,
-        "setup_fee": {
-          "value": "5",
-          "currency_code": "USD"
+      "payment_preferences"=> {
+        "auto_bill_outstanding"=> true,
+        "setup_fee"=> {
+          "value"=> "5",
+          "currency_code"=> "USD"
         },
-        "setup_fee_failure_action": "CONTINUE",
-        "payment_failure_threshold": 3
+        "setup_fee_failure_action"=> "CONTINUE",
+        "payment_failure_threshold"=> 3
       },
-      "taxes": {
-        "percentage": "12",
-        "inclusive": false
+      "taxes"=> {
+        "percentage"=> "12",
+        "inclusive"=> false
       },
-      "quantity_supported": true
+      "quantity_supported"=> true
 	}
 
 	start_time = (Time.now + 60).iso8601
 	SubscriptionAttributes = {
-	  "start_time": start_time,
-	  "quantity": "3",
-	  "shipping_amount": {
-	    "currency_code": "USD",
-	    "value": "9.00"
+	  "start_time"=> start_time,
+	  "quantity"=> "3",
+	  "shipping_amount"=> {
+	    "currency_code"=> "USD",
+	    "value"=> "9.00"
 	  },
-	  "subscriber": {
-	    "name": {
-	      "given_name": "John",
-	      "surname": "Doe"
+	  "subscriber"=> {
+	    "name"=> {
+	      "given_name"=> "John",
+	      "surname"=> "Doe"
 	    },
-	    "email_address": "customer@example.com",
-	    "shipping_address": {
-	      "name": {
-	        "full_name": "John Doe"
+	    "email_address"=> "customer@example.com",
+	    "shipping_address"=> {
+	      "name"=> {
+	        "full_name"=> "John Doe"
 	      },
-	      "address": {
-	        "address_line_1": "2211 N First Street",
-	        "address_line_2": "Building 17",
-	        "admin_area_2": "San Jose",
-	        "admin_area_1": "CA",
-	        "postal_code": "95131",
-	        "country_code": "US"
+	      "address"=> {
+	        "address_line_1"=> "2211 N First Street",
+	        "address_line_2"=> "Building 17",
+	        "admin_area_2"=> "San Jose",
+	        "admin_area_1"=> "CA",
+	        "postal_code"=> "95131",
+	        "country_code"=> "US"
 	      }
 	    }
 	  },
-	  "application_context": {
-	    "brand_name": "The Collegian",
-	    "locale": "en-US",
-	    "shipping_preference": "SET_PROVIDED_ADDRESS",
-	    "user_action": "SUBSCRIBE_NOW",
-	    "payment_method": {
-	      "payer_selected": "PAYPAL",
-	      "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+	  "application_context"=> {
+	    "brand_name"=> "The Collegian",
+	    "locale"=> "en-US",
+	    "shipping_preference"=> "SET_PROVIDED_ADDRESS",
+	    "user_action"=> "SUBSCRIBE_NOW",
+	    "payment_method"=> {
+	      "payer_selected"=> "PAYPAL",
+	      "payee_preferred"=> "IMMEDIATE_PAYMENT_REQUIRED"
 	    },
-	    "return_url": "https://example.com/returnUrl",
-	    "cancel_url": "https://example.com/cancelUrl"
+	    "return_url"=> "https://example.com/returnUrl",
+	    "cancel_url"=> "https://example.com/cancelUrl"
 	  }
 	}
 
 	PricingSchemeAttributes = 
 		{
-	      "billing_cycle_sequence": 2, #nth billing, must be unique to the plan
-	      "pricing_scheme": {
-	        "fixed_price": {
-	          "value": "35",
-	          "currency_code": "USD"
+	      "billing_cycle_sequence"=> 2, #nth billing, must be unique to the plan
+	      "pricing_scheme"=> {
+	        "fixed_price"=> {
+	          "value"=> "35",
+	          "currency_code"=> "USD"
 	        }
 	      }
 		}
 
 	OutstandingBalanceAttributes = {
-		"currency_code": "USD",
-		"value": "50.00"
+		"currency_code"=> "USD",
+		"value"=> "50.00"
 	}
 
 	describe "Product", :integration => true do
@@ -221,7 +221,7 @@ describe "Subscription" do
 		end
 
 		it "Update" do
-			$subscription = Subscription.find('I-0B7813AYW19B') #subscription created earlier needs to be approved by the user
+			$subscription = Subscription.find('I-VPS2DB7LBUSB') #subscription created earlier needs to be approved by the user
 			patch = Patch.new
 			patch.op = "replace"
 			patch.path = "/shipping_amount"

--- a/spec/subscription_2_examples_spec.rb
+++ b/spec/subscription_2_examples_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+describe "Subscription" do
+	ProductAttributes = {
+		"name": "The Collegian",
+		"description": "Official newsletter of CPM University",
+		"type": "PHYSICAL",
+		"category": "BOOKS_PERIODICALS_AND_NEWSPAPERS",
+		"image_url": "https://example.com",
+		"home_url": "https://example.com"
+	}
+
+	SubscriptionPlanAttributes = {
+	  "name": "Monthy Subscription to the Collegian",
+      "status": "ACTIVE",
+      "description": "1 print copy of The Collegian delivered to your address.",
+      "billing_cycles": [
+        {
+          "frequency": {
+            "interval_unit": "MONTH",
+            "interval_count": 1
+          },
+          "tenure_type": "TRIAL",
+          "sequence": 1,
+          "total_cycles": 1,
+          "pricing_scheme": {
+            "fixed_price": {
+              "value": "0",
+              "currency_code": "USD"
+            }
+          }
+        },
+        {
+          "frequency": {
+            "interval_unit": "MONTH",
+            "interval_count": 1
+          },
+          "tenure_type": "REGULAR",
+          "sequence": 2,
+          "total_cycles": 12,
+          "pricing_scheme": {
+            "fixed_price": {
+              "value": "29.99",
+              "currency_code": "USD"
+            }
+          }
+        }
+      ],
+      "payment_preferences": {
+        "auto_bill_outstanding": true,
+        "setup_fee": {
+          "value": "0",
+          "currency_code": "USD"
+        },
+        "setup_fee_failure_action": "CONTINUE",
+        "payment_failure_threshold": 3
+      },
+      "taxes": {
+        "percentage": "12",
+        "inclusive": false
+      },
+      "quantity_supported": true
+	}
+
+	SubscriptionAttributes = {
+	  "start_time": "2019-11-24T00:00:00Z",
+	  "quantity": "3",
+	  "shipping_amount": {
+	    "currency_code": "USD",
+	    "value": "9.00"
+	  },
+	  "subscriber": {
+	    "name": {
+	      "given_name": "John",
+	      "surname": "Doe"
+	    },
+	    "email_address": "customer@example.com",
+	    "shipping_address": {
+	      "name": {
+	        "full_name": "John Doe"
+	      },
+	      "address": {
+	        "address_line_1": "2211 N First Street",
+	        "address_line_2": "Building 17",
+	        "admin_area_2": "San Jose",
+	        "admin_area_1": "CA",
+	        "postal_code": "95131",
+	        "country_code": "US"
+	      }
+	    }
+	  },
+	  "application_context": {
+	    "brand_name": "The Collegian",
+	    "locale": "en-US",
+	    "shipping_preference": "SET_PROVIDED_ADDRESS",
+	    "user_action": "SUBSCRIBE_NOW",
+	    "payment_method": {
+	      "payer_selected": "PAYPAL",
+	      "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+	    },
+	    "return_url": "https://example.com/returnUrl",
+	    "cancel_url": "https://example.com/cancelUrl"
+	  }
+	}
+
+	describe "Product", :integration => true do
+		it "Create" do
+	      $api = API.new
+	      $product = Product.new(ProductAttributes.merge( :token => $api.token ))
+	      expect(Product.api).not_to eql $product.api
+	      $product.create
+
+	      # make sure the transaction was successful
+	      $product_id = $product.id
+	      expect($product.error).to be_nil
+	      expect($product.id).not_to be_nil
+	    end
+
+	    it "Find" do
+	      api = API.new
+	      product = Product.find($product.id)
+	      expect(product.id).to eq($product.id)
+	      expect(product.name).to eq("The Collegian")
+	      expect(product.type).to eq("PHYSICAL")
+	    end
+
+	    it "List" do
+	    	product_list = Product.all()
+      		expect(product_list.error).to be_nil
+      		expect(product_list.products.count).to be > 0
+	    end
+	end
+
+end


### PR DESCRIPTION
Created the following DataTypes to support the new subscription API  
- Product
- ProductList
- PaymentPreference
- SubscriptionPlan
- SubscriptionPlanList
- PricingSchemeList
- PricingScheme
- Subscription
- Subscriber
- ShippingAddress
- SubscriberName
- ShippingAddressName
- SubscriptionBillingInfo
- Frequency
- SubscriptionTransactionList
- SubscriptionTransaction

Included examples in spec/subscription_2_examples_spec.rb