### PR TITLE
Add recipient_wallet to allow venmo payouts

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -1713,6 +1713,7 @@ module PayPal::SDK
               object_of :note, String
               object_of :receiver, String
               object_of :sender_item_id, String
+              object_of :recipient_wallet, String
         end
 
         include RequestDataType

--- a/spec/payouts_examples_spec.rb
+++ b/spec/payouts_examples_spec.rb
@@ -2,6 +2,26 @@ require "spec_helper"
 
 describe "Payouts", :integration => true do
 
+
+  PayoutVenmotAttributes = {
+    :sender_batch_header => {
+      :sender_batch_id => SecureRandom.hex(8)
+  },
+  :items => [
+      {
+          :recipient_type => 'Phone',
+          :amount => {
+              :value => '1.0',
+              :currency => 'USD'
+          },
+          :note => 'Thanks for your patronage!',
+          :sender_item_id => '2014031400023',
+          :receiver => '1238675309',
+          :recipient_wallet => 'Venmo'
+      }
+    ]
+  }
+
   PayoutAttributes = {
       :sender_batch_header => {
           :sender_batch_id => SecureRandom.hex(8),
@@ -16,14 +36,19 @@ describe "Payouts", :integration => true do
               },
               :note => 'Thanks for your patronage!',
               :sender_item_id => '2014031400023',
-              :receiver => 'shirt-supplier-one@mail.com',
-              :recipient_walet => 'Paypal'
+              :receiver => 'shirt-supplier-one@mail.com'
           }
       ]
   }
 
   it "create payout sync" do
     $payout = PayPal::SDK::REST::Payout.new(PayoutAttributes)
+    $payout_batch = $payout.create(true)
+    expect($payout_batch).to be_truthy
+  end
+
+  it "create venmo payout" do 
+    $payout = PayPal::SDK::REST::Payout.new(PayoutVenmotAttributes)
     $payout_batch = $payout.create(true)
     expect($payout_batch).to be_truthy
   end

--- a/spec/payouts_examples_spec.rb
+++ b/spec/payouts_examples_spec.rb
@@ -16,7 +16,8 @@ describe "Payouts", :integration => true do
               },
               :note => 'Thanks for your patronage!',
               :sender_item_id => '2014031400023',
-              :receiver => 'shirt-supplier-one@mail.com'
+              :receiver => 'shirt-supplier-one@mail.com',
+              :recipient_walet => 'Paypal'
           }
       ]
   }

--- a/spec/payouts_examples_spec.rb
+++ b/spec/payouts_examples_spec.rb
@@ -9,7 +9,7 @@ describe "Payouts", :integration => true do
   },
   :items => [
       {
-          :recipient_type => 'Phone',
+          :recipient_type => 'PHONE',
           :amount => {
               :value => '1.0',
               :currency => 'USD'


### PR DESCRIPTION
The SDK is behind the docs, and there is no field for recipient_wallet for venmo https://developer.paypal.com/docs/payouts/features/payouts-to-venmo/